### PR TITLE
2. Add minimal pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
 [dependency-groups]
 typing = ["mypy"]
 linting = ["pylint"]
-dev = [{include-group = "typing"}, {include-group = "linting"}, "pre-commit"]
+tests = ["mock-serial", "pytest", "pytest-asyncio", "pytest-reserial"]
+dev = [{include-group = "typing"}, {include-group = "linting"}, {include-group = "tests"}, "pre-commit"]
 
 [project.urls]
 Homepage = "https://github.com/scabrero/pyairios"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,6 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pyairios"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src/", "."]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,4 @@
+mock-serial==0.0.1
+pytest==8.4.1
+pytest-asyncio==1.1.0
+pytest-reserial==0.4.3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,0 @@
-mock-serial==0.0.1
-pytest==8.4.1
-pytest-asyncio==1.1.0
-pytest-reserial==0.4.3

--- a/tests/test_one.py
+++ b/tests/test_one.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""pyairios minimal pytest suite."""
+
+import logging
+import sys
+
+import pytest
+from mock_serial import MockSerial
+from serial import Serial
+
+from cli import AiriosRootCLI
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format="%(levelname)s - %(message)s")
+
+
+class TestStartPyairiosCli:
+    """
+    Init CLI test.
+    """
+    def test_init_root(self):
+        device = MockSerial()
+        device.open()
+        serial = Serial(device.port)
+
+        # init CLI
+        cli = AiriosRootCLI()
+        assert cli, "no CLI"
+
+        # break down
+        serial.close()
+        device.close()
+
+        # TODO(eb): mock serial port so test can run, see pymodbus simulator + their tests

--- a/tests/test_one.py
+++ b/tests/test_one.py
@@ -4,7 +4,6 @@
 import logging
 import sys
 
-import pytest
 from mock_serial import MockSerial
 from serial import Serial
 
@@ -13,12 +12,12 @@ from cli import AiriosRootCLI
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format="%(levelname)s - %(message)s")
 
 
-class TestStartPyairiosCli:
+class TestStartPyairios:  # pylint: disable=too-few-public-methods
     """
-    CLI tests.
+    pyairios tests.
     """
 
-    def test_init_root(self) -> None:
+    def test_init_cli_root(self) -> None:
         """
         Test root level init of cli.py.
         """
@@ -34,4 +33,7 @@ class TestStartPyairiosCli:
         serial.close()
         device.close()
 
-        # TODO(eb): mock serial port so test can run, see pymodbus simulator + their tests
+    # TODO(eb): mock serial port so connect + next cli levels can run
+    #  see pymodbus simulator + their tests
+
+    # TODO(eb): add Airios api init test

--- a/tests/test_one.py
+++ b/tests/test_one.py
@@ -17,6 +17,7 @@ class TestStartPyairiosCli:
     """
     Init CLI test.
     """
+
     def test_init_root(self):
         device = MockSerial()
         device.open()

--- a/tests/test_one.py
+++ b/tests/test_one.py
@@ -15,10 +15,13 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format="%(levelname)
 
 class TestStartPyairiosCli:
     """
-    Init CLI test.
+    CLI tests.
     """
 
-    def test_init_root(self):
+    def test_init_root(self) -> None:
+        """
+        Test root level init of cli.py.
+        """
         device = MockSerial()
         device.open()
         serial = Serial(device.port)


### PR DESCRIPTION
Test pyairios core loading by starting cli
Follows pytest instructions.

At any pyairios development stage this test proved handy to catch typos etc immediately.
As marked TODO, wish to add some mocked modbus simulator when that tool is released in pymodbus 4, see [docs](https://pymodbus.readthedocs.io/en/v3.10.0/source/simulator/server.html)

Ignored import sort errors flagged by ruff in files not touched (they will be fixed in PR #9)