### PR TITLE
Refactor Ventura

### DIFF
--- a/src/pyairios/__init__.py
+++ b/src/pyairios/__init__.py
@@ -1,6 +1,7 @@
 """The Airios RF bridge API entrypoint."""
 
 import logging
+from types import ModuleType
 
 from pyairios.models.brdg_02r13 import BRDG02R13
 from pyairios.models.brdg_02r13 import DEFAULT_SLAVE_ID as BRDG02R13_DEFAULT_SLAVE_ID
@@ -48,6 +49,18 @@ class Airios:
     async def node(self, slave_id: int) -> AiriosNode:
         """Get a node instance by its Modbus slave ID."""
         return await self.bridge.node(slave_id)
+
+    async def models(self) -> dict[str, ModuleType] | None:
+        """Get the list of supported models."""
+        return await self.bridge.models()
+
+    async def prids(self) -> dict[str, int] | None:
+        """Get the list of supported product_id's."""
+        return await self.bridge.product_ids()
+
+    async def model_descriptions(self) -> dict[str, str] | None:
+        """Get the list of supported product_id's."""
+        return await self.bridge.model_descriptions()
 
     async def bind_status(self) -> BindingStatus:
         """Get the bind status."""

--- a/src/pyairios/__init__.py
+++ b/src/pyairios/__init__.py
@@ -87,8 +87,8 @@ class Airios:
 
         prids = brdg_data["product_ids"]
         if prids is not None and brdg_data["models"] is not None:
-            for _node in await self.bridge.nodes():
-                for key, _id in prids.items():
+            for _node in await self.bridge.nodes():  # for each bound node (slow)
+                for key, _id in prids.items():  # find a matching model (quick)
                     if _id == _node.product_id and brdg_data["models"][key] is not None:
                         LOGGER.debug("fetch_node_data for key: %s", key)
                         node_module = brdg_data["models"][key].Node(

--- a/src/pyairios/__init__.py
+++ b/src/pyairios/__init__.py
@@ -80,19 +80,22 @@ class Airios:
         data: dict[int, AiriosNodeData] = {}
 
         brdg_data = await self.bridge.fetch_bridge_data()
-        if brdg_data["rf_address"] is None:
+        if brdg_data is None or brdg_data["rf_address"] is None:
             raise AiriosException("Failed to fetch node RF address")
         bridge_rf_address = brdg_data["rf_address"].value
         data[self.bridge.slave_id] = brdg_data
 
         prids = brdg_data["product_ids"]
-        for _node in await self.bridge.nodes():
-            for key, _id in prids.items():
-                if _id == _node.product_id:
-                    LOGGER.debug("fetch_node_data for key: %s", key)
-                    node_module = brdg_data["models"][key].Node(_node.slave_id, self.bridge.client)
-                    node_data = await node_module.fetch_node_data()
-                    data[_node.slave_id] = node_data
+        if prids is not None:
+            for _node in await self.bridge.nodes():
+                for key, _id in prids.items():
+                    if _id == _node.product_id:
+                        LOGGER.debug("fetch_node_data for key: %s", key)
+                        node_module = brdg_data["models"][key].Node(
+                            _node.slave_id, self.bridge.client
+                        )
+                        node_data = await node_module.fetch_node_data()
+                        data[_node.slave_id] = node_data
 
         return AiriosData(bridge_rf_address=bridge_rf_address, nodes=data)
 

--- a/src/pyairios/__init__.py
+++ b/src/pyairios/__init__.py
@@ -50,16 +50,16 @@ class Airios:
         """Get a node instance by its Modbus slave ID."""
         return await self.bridge.node(slave_id)
 
-    async def models(self) -> dict[str, ModuleType] | None:
+    async def airios_models(self) -> dict[str, ModuleType] | None:
         """Get the list of supported models."""
         return await self.bridge.models()
 
-    async def prids(self) -> dict[str, int] | None:
+    async def airios_prids(self) -> dict[str, int] | None:
         """Get the list of supported product_id's."""
         return await self.bridge.product_ids()
 
-    async def model_descriptions(self) -> dict[str, str] | None:
-        """Get the list of supported product_id's."""
+    async def airios_model_descr(self) -> dict[str, str] | None:
+        """Get the list of supported model descriptions."""
         return await self.bridge.model_descriptions()
 
     async def bind_status(self) -> BindingStatus:

--- a/src/pyairios/__init__.py
+++ b/src/pyairios/__init__.py
@@ -98,15 +98,14 @@ class Airios:
         bridge_rf_address = brdg_data["rf_address"].value
         data[self.bridge.slave_id] = brdg_data
 
-        prids = brdg_data["product_ids"]
-        if prids is not None and brdg_data["models"] is not None:
+        prids = await self.bridge.product_ids()
+        models = await self.bridge.models()
+        if prids is not None and models is not None:
             for _node in await self.bridge.nodes():  # for each bound node (slow)
                 for key, _id in prids.items():  # find a matching model (quick)
-                    if _id == _node.product_id and brdg_data["models"][key] is not None:
+                    if _id == _node.product_id and models[key] is not None:
                         LOGGER.debug("fetch_node_data for key: %s", key)
-                        node_module = brdg_data["models"][key].Node(
-                            _node.slave_id, self.bridge.client
-                        )
+                        node_module = models[key].Node(_node.slave_id, self.bridge.client)
                         node_data = await node_module.fetch_node_data()
                         data[_node.slave_id] = node_data
 

--- a/src/pyairios/__init__.py
+++ b/src/pyairios/__init__.py
@@ -89,7 +89,7 @@ class Airios:
         if prids is not None:
             for _node in await self.bridge.nodes():
                 for key, _id in prids.items():
-                    if _id == _node.product_id:
+                    if _id == _node.product_id and brdg_data["models"][key] is not None:
                         LOGGER.debug("fetch_node_data for key: %s", key)
                         node_module = brdg_data["models"][key].Node(
                             _node.slave_id, self.bridge.client

--- a/src/pyairios/__init__.py
+++ b/src/pyairios/__init__.py
@@ -15,7 +15,12 @@ from .client import (
     AsyncAiriosModbusTcpClient,
 )
 from .constants import BindingStatus
-from .data_model import AiriosBoundNodeInfo, AiriosData, AiriosNodeData
+from .data_model import (
+    AiriosBoundNodeInfo,
+    AiriosData,
+    AiriosDeviceData,
+    BRDG02R13Data,
+)
 from .exceptions import AiriosException
 from .node import AiriosNode
 
@@ -90,7 +95,7 @@ class Airios:
 
     async def fetch(self) -> AiriosData:
         """Get the data from all nodes at once."""
-        data: dict[int, AiriosNodeData] = {}
+        data: dict[int, AiriosDeviceData | BRDG02R13Data] = {}
 
         brdg_data = await self.bridge.fetch_bridge_data()
         if brdg_data is None or brdg_data["rf_address"] is None:
@@ -106,7 +111,7 @@ class Airios:
                     if _id == _node.product_id and models[key] is not None:
                         LOGGER.debug("fetch_node_data for key: %s", key)
                         node_module = models[key].Node(_node.slave_id, self.bridge.client)
-                        node_data = await node_module.fetch_node_data()
+                        node_data = await node_module.fetch_node_data()  # extended DeviceData
                         data[_node.slave_id] = node_data
 
         return AiriosData(bridge_rf_address=bridge_rf_address, nodes=data)

--- a/src/pyairios/__init__.py
+++ b/src/pyairios/__init__.py
@@ -86,7 +86,7 @@ class Airios:
         data[self.bridge.slave_id] = brdg_data
 
         prids = brdg_data["product_ids"]
-        if prids is not None:
+        if prids is not None and brdg_data["models"] is not None:
             for _node in await self.bridge.nodes():
                 for key, _id in prids.items():
                     if _id == _node.product_id and brdg_data["models"][key] is not None:

--- a/src/pyairios/client.py
+++ b/src/pyairios/client.py
@@ -1,4 +1,4 @@
-"""Async client for the Airios BRDB-02R13 Modbus gateway."""
+"""Async client for the Airios BRDG-02R13 Modbus gateway."""
 
 from __future__ import annotations
 

--- a/src/pyairios/constants.py
+++ b/src/pyairios/constants.py
@@ -6,29 +6,18 @@ from enum import Flag, IntEnum, auto
 
 
 class ProductId(IntEnum):
-    """The product ID is a unique product identifier.
-
-    The value is composed by three fields, product type + sub ID + manufacturer ID.
+    """
+    The product ID is a unique product identifier.
+    The value is composed of three fields: product type + sub ID + manufacturer ID.
+    Replaced by pr_id dynamic dict, created during _init_ in BRDG
     """
 
-    BRDG_02R13 = 0x0001C849
-    VMD_02RPS78 = 0x0001C892
-    VMN_05LM02 = 0x0001C83E
-    VMN_02LM11 = 0x0001C852
-    VMD_07RPS13 = 0x0001C883  # ClimaRad VenturaV1X
-
-    def __str__(self) -> str:
-        if self.value == self.BRDG_02R13:
-            return "BRDG-02R13"
-        if self.value == self.VMD_02RPS78:
-            return "VMD-02RPS78"
-        if self.value == self.VMN_05LM02:
-            return "VMN-05LM02"
-        if self.value == self.VMN_02LM11:
-            return "VMN-02LM11"
-        if self.value == self.VMD_07RPS13:
-            return "VMD-07RPS13"
-        raise ValueError(f"Unknown product ID value {self.value}")
+    # this info was moved to the models/ class files as pr_id
+    # get the dict from bridge by calling bridge.product_ids
+    # they will be unique as long as all files are in flat models/ dir
+    # new definitions will be picked up automatically when dropped there
+    # only Bridge product_id required as const, used during api init
+    BRDG_02R13 = 0x0001C849  # RF Bridge
 
 
 class BoundStatus(IntEnum):
@@ -368,6 +357,7 @@ class VMDHeater:
 class VMDCapabilities(Flag):
     """Ventilation unit capabilities."""
 
+    NO_CAPABLE = 0x0000
     PRE_HEATER_AVAILABLE = 0x0001
     POST_HEATER_AVAILABLE = 0x0002
     RESERVED = 0x0004
@@ -391,6 +381,53 @@ class VMDFaultStatus(IntEnum):
 
     OK = 0
     FAN_FAILURE = 1
+
+
+class VMDOffOnMode(IntEnum):
+    """General use binary state."""
+
+    OFF = 0
+    ON = 1
+    UNKNOWN = 10  # not in specs
+
+
+class VMDVentilationMode(IntEnum):
+    """Ventilation unit (Ventura) mode preset."""
+
+    OFF = 0
+    PAUSE = 1
+    ON = 2
+    OVERRIDE_1 = 3
+    OVERRIDE_2 = 4
+    OVERRIDE_3 = 5
+    OVERRIDE_4 = 6
+    OVERRIDE_5 = 7
+    SERVICE = 8
+    RETYPE = 9
+    UNKNOWN = 10  # not in specs
+
+    def __str__(self) -> str:  # pylint: disable=too-many-return-statements
+        if self.value == self.OFF:
+            return "Off"
+        if self.value == self.PAUSE:
+            return "Pause"
+        if self.value == self.ON:
+            return "On/Auto"
+        if self.value == self.OVERRIDE_1:
+            return "I (temporary override)"
+        if self.value == self.OVERRIDE_2:
+            return "II (temporary override)"
+        if self.value == self.OVERRIDE_3:
+            return "III (temporary override)"
+        if self.value == self.OVERRIDE_4:
+            return "IV (temporary override)"
+        if self.value == self.OVERRIDE_5:
+            return "V (temporary override)"
+        if self.value == self.SERVICE:
+            return "Service Mode"
+        if self.value == self.RETYPE:
+            return "Retype (see manual)"
+        raise ValueError(f"Unknown ventilation mode value {self.value}")
 
 
 class VMDVentilationSpeed(IntEnum):
@@ -590,5 +627,6 @@ class VMDBypassMode(IntEnum):
 class VMDBypassPosition:
     """VMD bypass position sample."""
 
+    # Ventura bp_position: 0 = closed, 100 = open
     position: int
     error: bool

--- a/src/pyairios/constants.py
+++ b/src/pyairios/constants.py
@@ -104,7 +104,7 @@ class RFStats:
         """RF statistic record."""
 
         device_id: int
-        averate: int
+        average: int
         """Average received signal strength margin  of RF beacon (dB)."""
         stddev: float
         """Standard deviation of received signal strength margin of RF beacon (.1 dB)."""

--- a/src/pyairios/data_model.py
+++ b/src/pyairios/data_model.py
@@ -2,22 +2,15 @@
 
 from dataclasses import dataclass
 from datetime import timedelta
+from types import ModuleType
 from typing import TypedDict
 
 from pyairios.constants import (
     BatteryStatus,
     BoundStatus,
     FaultStatus,
-    ProductId,
     RFCommStatus,
     ValueErrorStatus,
-    VMDBypassMode,
-    VMDBypassPosition,
-    VMDErrorCode,
-    VMDHeater,
-    VMDRequestedVentilationSpeed,
-    VMDTemperature,
-    VMDVentilationSpeed,
 )
 from pyairios.registers import Result
 
@@ -27,7 +20,7 @@ class AiriosBoundNodeInfo:
     """Bridge bound node information."""
 
     slave_id: int
-    product_id: ProductId
+    product_id: int
     rf_address: int
 
 
@@ -36,7 +29,7 @@ class AiriosNodeData(TypedDict):
 
     slave_id: int
     rf_address: Result[int] | None
-    product_id: Result[ProductId] | None
+    product_id: Result[int] | None
     product_name: Result[str] | None
     sw_version: Result[int] | None
     rf_comm_status: Result[RFCommStatus] | None
@@ -51,41 +44,8 @@ class AiriosDeviceData(AiriosNodeData):
     value_error_status: Result[ValueErrorStatus] | None
 
 
-class VMD02RPS78Data(AiriosDeviceData):
-    """VMD-02RPS78 node data."""
-
-    error_code: Result[VMDErrorCode] | None
-    ventilation_speed: Result[VMDVentilationSpeed] | None
-    override_remaining_time: Result[int] | None
-    exhaust_fan_speed: Result[int] | None
-    supply_fan_speed: Result[int] | None
-    exhaust_fan_rpm: Result[int] | None
-    supply_fan_rpm: Result[int] | None
-    indoor_air_temperature: Result[VMDTemperature] | None
-    outdoor_air_temperature: Result[VMDTemperature] | None
-    exhaust_air_temperature: Result[VMDTemperature] | None
-    supply_air_temperature: Result[VMDTemperature] | None
-    filter_dirty: Result[int] | None
-    filter_remaining_percent: Result[int] | None
-    filter_duration_days: Result[int] | None
-    bypass_position: Result[VMDBypassPosition] | None
-    bypass_mode: Result[VMDBypassMode] | None
-    bypass_status: Result[int] | None
-    defrost: Result[int] | None
-    preheater: Result[VMDHeater] | None
-    postheater: Result[VMDHeater] | None
-    preheater_setpoint: Result[float] | None
-    free_ventilation_setpoint: Result[float] | None
-    free_ventilation_cooling_offset: Result[float] | None
-    frost_protection_preheater_setpoint: Result[float] | None
-    preset_high_fan_speed_supply: Result[int] | None
-    preset_high_fan_speed_exhaust: Result[int] | None
-    preset_medium_fan_speed_supply: Result[int] | None
-    preset_medium_fan_speed_exhaust: Result[int] | None
-    preset_low_fan_speed_supply: Result[int] | None
-    preset_low_fan_speed_exhaust: Result[int] | None
-    preset_standby_fan_speed_supply: Result[int] | None
-    preset_standby_fan_speed_exhaust: Result[int] | None
+# Here only data_models for special devices. To simplify adding new models,
+# 'normal' node data_models, all named Data, are in their respective models/module file
 
 
 class BRDG02R13Data(AiriosNodeData):
@@ -96,12 +56,10 @@ class BRDG02R13Data(AiriosNodeData):
     rf_load_last_hour: Result[float] | None
     rf_load_current_hour: Result[float] | None
     power_on_time: Result[timedelta] | None
-
-
-class VMN05LM02Data(AiriosDeviceData):
-    """VMN-05LM02 node data."""
-
-    requested_ventilation_speed: Result[VMDRequestedVentilationSpeed] | None
+    # Bridge holds info collected from models/ definition at startup:
+    models: dict[str, ModuleType] | None
+    model_descriptions: dict[str, str] | None
+    product_ids: dict[str, int] | None
 
 
 @dataclass
@@ -109,4 +67,4 @@ class AiriosData:
     """Data from all bridge bound nodes."""
 
     bridge_rf_address: int
-    nodes: dict[int, AiriosNodeData]
+    nodes: dict[int, AiriosNodeData | BRDG02R13Data]

--- a/src/pyairios/data_model.py
+++ b/src/pyairios/data_model.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from datetime import timedelta
-from types import ModuleType
 from typing import TypedDict
 
 from pyairios.constants import (
@@ -45,7 +44,7 @@ class AiriosDeviceData(AiriosNodeData):
 
 
 # Here only data_models for special devices. To simplify adding new models,
-# 'normal' node data_models, all named Data, are in their respective models/module file
+# 'normal' node data_models, all named DeviceData, are in their respective models/module file
 
 
 class BRDG02R13Data(AiriosNodeData):
@@ -56,10 +55,6 @@ class BRDG02R13Data(AiriosNodeData):
     rf_load_last_hour: Result[float] | None
     rf_load_current_hour: Result[float] | None
     power_on_time: Result[timedelta] | None
-    # Bridge holds info collected from models/ definition at startup:
-    models: dict[str, ModuleType] | None
-    model_descriptions: dict[str, str] | None
-    product_ids: dict[str, int] | None
 
 
 @dataclass
@@ -67,4 +62,4 @@ class AiriosData:
     """Data from all bridge bound nodes."""
 
     bridge_rf_address: int
-    nodes: dict[int, AiriosNodeData | BRDG02R13Data]
+    nodes: dict[int, AiriosDeviceData]

--- a/src/pyairios/data_model.py
+++ b/src/pyairios/data_model.py
@@ -62,4 +62,4 @@ class AiriosData:
     """Data from all bridge bound nodes."""
 
     bridge_rf_address: int
-    nodes: dict[int, AiriosDeviceData]
+    nodes: dict[int, AiriosDeviceData | BRDG02R13Data]

--- a/src/pyairios/device.py
+++ b/src/pyairios/device.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import re
 from typing import List
 
 from .client import AsyncAiriosModbusClient
 from .constants import BoundStatus, ValueErrorStatus
 from .data_model import AiriosDeviceData
-from .node import AiriosNode
+from .node import AiriosNode, _safe_fetch
 from .registers import (
     I16Register,
     RegisterAccess,
@@ -41,6 +42,10 @@ class AiriosDevice(AiriosNode):
         ]
         self._add_registers(dev_registers)
 
+    def __str__(self) -> str:
+        prompt = str(re.sub(r"_", "-", self.__module__.upper()))
+        return f"{prompt}@{self.slave_id}"
+
     async def device_bound_status(self) -> Result[BoundStatus]:
         """Get the device bound status."""
         result = await self.client.get_register(self.regmap[Reg.BOUND_STATUS], self.slave_id)
@@ -56,13 +61,13 @@ class AiriosDevice(AiriosNode):
 
         return AiriosDeviceData(
             slave_id=self.slave_id,
-            rf_address=await self._safe_fetch(self.node_rf_address),
-            product_id=await self._safe_fetch(self.node_product_id),
-            sw_version=await self._safe_fetch(self.node_software_version),
-            product_name=await self._safe_fetch(self.node_product_name),
-            rf_comm_status=await self._safe_fetch(self.node_rf_comm_status),
-            battery_status=await self._safe_fetch(self.node_battery_status),
-            fault_status=await self._safe_fetch(self.node_fault_status),
-            bound_status=await self._safe_fetch(self.device_bound_status),
-            value_error_status=await self._safe_fetch(self.device_value_error_status),
+            rf_address=await _safe_fetch(self.node_rf_address),
+            product_id=await _safe_fetch(self.node_product_id),
+            sw_version=await _safe_fetch(self.node_software_version),
+            product_name=await _safe_fetch(self.node_product_name),
+            rf_comm_status=await _safe_fetch(self.node_rf_comm_status),
+            battery_status=await _safe_fetch(self.node_battery_status),
+            fault_status=await _safe_fetch(self.node_fault_status),
+            bound_status=await _safe_fetch(self.device_bound_status),
+            value_error_status=await _safe_fetch(self.device_value_error_status),
         )

--- a/src/pyairios/models/brdg_02r13.py
+++ b/src/pyairios/models/brdg_02r13.py
@@ -541,10 +541,6 @@ class BRDG02R13(BrdgBase):
             rf_load_last_hour=await _safe_fetch(self.rf_load_last_hour),
             rf_load_current_hour=await _safe_fetch(self.rf_load_current_hour),
             power_on_time=await _safe_fetch(self.power_on_time),
-            # add info from ALL definitions in models/
-            models=await self.models(),
-            model_descriptions=await self.model_descriptions(),
-            product_ids=await self.product_ids(),
         )
 
     async def print_data(self) -> None:

--- a/src/pyairios/models/brdg_02r13.py
+++ b/src/pyairios/models/brdg_02r13.py
@@ -689,7 +689,8 @@ class BRDG02R13(AiriosNode):
         print(f"    {'Uptime:': <40}{res['power_on_time']}")
         print("")
 
-        print(f"{len(res['models'])} Installed model files")
+        size = len([key for key in res['models']])
+        print(f"Installed {size} model files")
         # print(res['models'])
         for key, mod in res["models"].items():
             print(f"    {key[:3]}{':': <37}{key} {str(mod.Node)} {mod.product_descr} {mod.pr_id}")

--- a/src/pyairios/models/brdg_02r13.py
+++ b/src/pyairios/models/brdg_02r13.py
@@ -275,6 +275,8 @@ class BRDG02R13(AiriosNode):
                 # store the spec in a dict by class name:
                 mod = importlib.util.module_from_spec(module_spec)
                 # load the module from the spec:
+                if mod is None:
+                    raise AiriosException(f"Failed to load module_from_spec {module_name}")
                 module_spec.loader.exec_module(mod)
                 # store the imported module in dict:
                 self.modules[model_key] = mod
@@ -693,8 +695,10 @@ class BRDG02R13(AiriosNode):
         print("")
 
         amount = 0 if res["models"] is None else len(res["models"])
-        print(f"Installed {amount} model files")
-        # print(res['models'])
-        for key, mod in res["models"].items():
-            print(f"    {key[:3]}{':': <37}{key} {str(mod.Node)} {mod.product_descr} {mod.pr_id}")
+        print(f"Loaded {amount} model files")
+        if res["models"] is not None:
+            for key, mod in res["models"].items():
+                print(
+                    f"    {key[:3]}{':': <37}{key} {str(mod.Node)} {mod.product_descr} {mod.pr_id}"
+                )
         # print(f"    {'ProductIDs:': <40}{res['product_ids']}")

--- a/src/pyairios/models/brdg_02r13.py
+++ b/src/pyairios/models/brdg_02r13.py
@@ -555,20 +555,7 @@ class BRDG02R13(BrdgBase):
         """
         res = await self.fetch_bridge_data()  # customised per model
 
-        print("Node data")
-        print("---------")
-        print(f"    {'Product ID:': <25}{res['product_id']} (0x{res['product_id']:08X})")
-        print(f"    {'Product Name:': <25}{res['product_name']}")
-        print(f"    {'Software version:': <25}{res['sw_version']}")
-        print(f"    {'RF address:': <25}{res['rf_address']}")
-        print("")
-
-        print("Device data")
-        print("---------")
-        print(f"    {'RF comm status:': <25}{res['rf_comm_status']}")
-        print(f"    {'Battery status:': <25}{res['battery_status']}")
-        print(f"    {'Fault status:': <25}{res['fault_status']}")
-        print("")
+        super().print_base_data(res)
 
         print("BRDG-02R13 data")
         print("----------------")
@@ -578,12 +565,3 @@ class BRDG02R13(BrdgBase):
         print(f"    {'RF load current hour:': <40}{res['rf_load_current_hour']}")
         print(f"    {'Uptime:': <40}{res['power_on_time']}")
         print("")
-
-        amount = 0 if res["models"] is None else len(res["models"])
-        print(f"Loaded {amount} model files")
-        if res["models"] is not None:
-            for key, mod in res["models"].items():
-                print(
-                    f"    {key[:3]}{':': <37}{key} {str(mod.Node)} {mod.product_descr} {mod.pr_id}"
-                )
-        # print(f"    {'ProductIDs:': <40}{res['product_ids']}")

--- a/src/pyairios/models/brdg_02r13.py
+++ b/src/pyairios/models/brdg_02r13.py
@@ -689,8 +689,7 @@ class BRDG02R13(AiriosNode):
         print(f"    {'Uptime:': <40}{res['power_on_time']}")
         print("")
 
-        size = len([key for key in res['models']])
-        print(f"Installed {size} model files")
+        print(f"Installed {len(list(res['models']))} model files")
         # print(res['models'])
         for key, mod in res["models"].items():
             print(f"    {key[:3]}{':': <37}{key} {str(mod.Node)} {mod.product_descr} {mod.pr_id}")

--- a/src/pyairios/models/brdg_02r13.py
+++ b/src/pyairios/models/brdg_02r13.py
@@ -270,7 +270,7 @@ class BRDG02R13(AiriosNode):
 
                 # using importlib, create a spec for each module:
                 module_spec = importlib.util.spec_from_file_location(module_name, file_path)
-                if module_spec is None:
+                if module_spec is None or module_spec.loader is None:
                     raise AiriosException(f"Failed to load module {module_name}")
                 # store the spec in a dict by class name:
                 mod = importlib.util.module_from_spec(module_spec)
@@ -535,10 +535,10 @@ class BRDG02R13(AiriosNode):
         if slave_id == self.slave_id:
             return self  # the bridge as node
 
-        for nd in await self.nodes():
-            if nd.slave_id != slave_id:
+        for _node in await self.nodes():
+            if _node.slave_id != slave_id:
                 continue
-            key = str(nd.product_id)  # compare to cli.py and _init_.py
+            key = str(_node.product_id)  # compare to cli.py and _init_.py
             LOGGER.debug("Fetch matching module for: %s", key)
             return self.modules[key].Node(slave_id, self.client)
 

--- a/src/pyairios/models/brdg_02r13.py
+++ b/src/pyairios/models/brdg_02r13.py
@@ -259,14 +259,16 @@ class BRDG02R13(AiriosNode):
                     file_name == "__init__.py"
                     # or file_name == "brdg_02r13.py"  # bridge also has sensors that need this info
                     or file_name.endswith("_base.py")
-                ):  # skip BRDG and the base model definitions
+                ):  # skip init and any base model definitions
                     continue
                 module_name = file_name.removesuffix(".py")
+                assert module_name is not None
                 model_key: str = str(re.sub(r"_", "-", module_name).upper())
                 assert model_key is not None
 
                 # using importlib, create a spec for each module:
                 module_spec = importlib.util.spec_from_file_location(module_name, file_path)
+                assert module_spec is not None
                 # store the spec in a dict by class name:
                 mod = importlib.util.module_from_spec(module_spec)
                 # load the module from the spec:

--- a/src/pyairios/models/brdg_02r13.py
+++ b/src/pyairios/models/brdg_02r13.py
@@ -293,7 +293,7 @@ class BRDG02R13(AiriosNode):
                     )
                 self.prids[model_key] = _id
                 check_id.append(_id)  # remember all added _id's to check for duplicates
-                self.descriptions[model_key] = self.modules[model_key].product_descr
+                self.descriptions[model_key] = self.modules[model_key].product_descr()
 
             LOGGER.debug("Loaded modules:")
             LOGGER.debug(self.modules)  # dict

--- a/src/pyairios/models/brdg_02r13.py
+++ b/src/pyairios/models/brdg_02r13.py
@@ -667,7 +667,7 @@ class BRDG02R13(AiriosNode):
 
         print("Node data")
         print("---------")
-        print(f"    {'Product ID:': <25}{res['product_id']} (0x{int(res['product_id'].value):08X})")
+        print(f"    {'Product ID:': <25}{res['product_id']} (0x{res['product_id']:08X})")
         print(f"    {'Product Name:': <25}{res['product_name']}")
         print(f"    {'Software version:': <25}{res['sw_version']}")
         print(f"    {'RF address:': <25}{res['rf_address']}")

--- a/src/pyairios/models/brdg_base.py
+++ b/src/pyairios/models/brdg_base.py
@@ -1,0 +1,181 @@
+"""Airios BRDG-BASE controller implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import glob
+import importlib.util
+import logging
+import os
+import re
+from types import ModuleType
+
+from pyairios.device import AiriosDevice
+from pyairios.exceptions import AiriosException
+from pyairios.registers import RegisterAddress
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Reg(RegisterAddress):
+    """Register set for BRDG-BASE controller node."""
+
+
+def pr_id() -> int:
+    """
+    Get product_id for model BRDG- models.
+    Named as is to discern from node.product_id register.
+    :return: unique int
+    """
+    # base class, should not be called
+    return 0x0
+
+
+def product_descr() -> str | tuple[str, ...]:
+    """
+    Get description of product(s) using BRDG_xxxx.
+    Human-readable text, used in e.g. HomeAssistant Binding UI.
+    :return: string or tuple of strings, starting with manufacturer
+    """
+    # base class, should not be called
+    return "-"
+
+
+class BrdgBase(AiriosDevice):
+    """Base class for BRDG-xxx bridge nodes.
+    Only contains common Airios support methods, available to all bridge implementations.
+    """
+
+    modules: dict[str, ModuleType] = {}
+    # a dict with imported modules by model
+    prids: dict[str, int] = {}
+    # a dict with product_ids by model (replaces ProductId enum in const.py)
+    descriptions: dict[str, str] = {}
+    # a dict with label description model, for use in UI
+    modules_loaded: bool = False
+
+    async def load_models(self) -> int:
+        """
+        Analyse and import all VMx.py files from the models/ folder.
+        """
+        if not self.modules_loaded:
+            loop = asyncio.get_running_loop()
+            # must call this async run_in_executor to prevent HA blocking call during file I/O.
+            modules_list = await loop.run_in_executor(
+                None, glob.glob, os.path.join(os.path.dirname(__file__), "*.py")
+            )
+            # we are in models/
+            check_id = []
+
+            for file_path in modules_list:
+                file_name = str(os.path.basename(file_path))
+                if (
+                    file_name == "__init__.py" or file_name.endswith("_base.py")
+                    # or file_name == "brdg_02r13.py"  # bridges have sensors that need this info
+                ):  # skip init and any base model definitions
+                    continue
+                module_name = file_name.removesuffix(".py")
+                if module_name is None:
+                    raise AiriosException(f"Failed to extract mod_name from filename {file_name}")
+                model_key: str = str(re.sub(r"_", "-", module_name).upper())
+                if model_key is None:
+                    raise AiriosException(f"Failed to create model_key from {module_name}")
+
+                # using importlib, create a spec for each module:
+                module_spec = importlib.util.spec_from_file_location(module_name, file_path)
+                if module_spec is None or module_spec.loader is None:
+                    raise AiriosException(f"Failed to load module {module_name}")
+                # store the spec in a dict by class name:
+                mod = importlib.util.module_from_spec(module_spec)
+                # load the module from the spec:
+                if mod is None:
+                    raise AiriosException(f"Failed to load module_from_spec {module_name}")
+                module_spec.loader.exec_module(mod)
+                # store the imported module in dict:
+                self.modules[model_key] = mod
+
+                # now we can use the module as if it were imported normally
+                # check correct loading by fetching the product_id
+                # (the int to check binding against)
+                _id = self.modules[model_key].pr_id()
+                # verify no duplicate product_id's
+                if _id in check_id:  #  product_id not unique among models
+                    raise AiriosException(
+                        f"Found duplicate product_id while collecting models:id {model_key}"
+                        f"used by {self.modules[model_key].__name__} and by {mod.__name__}"
+                    )
+                self.prids[model_key] = _id
+                check_id.append(_id)  # remember all added _id's to check for duplicates
+                self.descriptions[model_key] = self.modules[model_key].product_descr()
+
+            LOGGER.debug("Loaded modules:")
+            LOGGER.debug(self.modules)  # dict
+            LOGGER.info("Loaded product_id's:")
+            LOGGER.info(self.prids)  # dict
+            LOGGER.info("Loaded products:")
+            LOGGER.info(self.descriptions)  # dict
+            # all loaded up
+            self.modules_loaded = True
+        return len(self.modules)
+
+    async def models(self) -> dict[str, ModuleType] | None:
+        """
+        Util to fetch all supported models with their imported module class.
+        Must call this async run_in_executor to prevent HA blocking call during file I/O.
+
+        :return: dict of all controller and accessory modules by key
+        """
+        if not self.modules_loaded:
+            task = asyncio.create_task(self.load_models())
+            await task
+            return self.modules
+        return self.modules
+
+    async def model_descriptions(self) -> dict[str, str] | None:
+        """
+        Util to fetch all supported model labels.
+
+        :return: dict of all controller and accessory module labels by key
+        """
+        if not self.modules_loaded:
+            task = asyncio.create_task(self.load_models())
+            await task
+            return self.descriptions
+        return self.descriptions
+
+    async def product_ids(self) -> dict[str, int] | None:
+        """
+        Util to pick up all supported models with their productId.
+
+        :return: dict of all controller and accessory definitions installed
+        """
+        if not self.modules_loaded:
+            task = asyncio.create_task(self.load_models())
+            await task
+            return self.prids
+        return self.prids
+
+    def print_base_data(self, res) -> None:
+        """
+        Print shared VMD labels + states, in CLI.
+
+        :return: no confirmation, outputs to serial monitor
+        """
+        print("Node data")
+        print("---------")
+        print(f"    {'Product ID:': <25}{res['product_id']} (0x{res['product_id']:08X})")
+        print(f"    {'Product Name:': <25}{res['product_name']}")
+        print(f"    {'Software version:': <25}{res['sw_version']}")
+        print(f"    {'RF address:': <25}{res['rf_address']}")
+        print("")
+
+        print("Device data")
+        print("---------")
+        print(f"    {'RF comm status:': <25}{res['rf_comm_status']}")
+        print(f"    {'Battery status:': <25}{res['battery_status']}")
+        print(f"    {'Fault status:': <25}{res['fault_status']}")
+        print(f"    {'Bound status:': <25}{res['bound_status']}")
+        print(f"    {'Value error status:': <25}{res['value_error_status']}")
+        print("")
+
+        print("----------------")

--- a/src/pyairios/models/brdg_base.py
+++ b/src/pyairios/models/brdg_base.py
@@ -157,7 +157,7 @@ class BrdgBase(AiriosDevice):
 
     def print_base_data(self, res) -> None:
         """
-        Print shared VMD labels + states, in CLI.
+        Print shared BRDG labels + states, in CLI.
 
         :return: no confirmation, outputs to serial monitor
         """
@@ -174,8 +174,15 @@ class BrdgBase(AiriosDevice):
         print(f"    {'RF comm status:': <25}{res['rf_comm_status']}")
         print(f"    {'Battery status:': <25}{res['battery_status']}")
         print(f"    {'Fault status:': <25}{res['fault_status']}")
-        print(f"    {'Bound status:': <25}{res['bound_status']}")
-        print(f"    {'Value error status:': <25}{res['value_error_status']}")
         print("")
+
+        amount = 0 if self.modules is None else len(self.modules)
+        print(f"Loaded {amount} model files")
+        if self.modules is not None:
+            for key, mod in self.modules.items():
+                report1 = f"{key[:3]}{':': <6}{key: <14}name: {mod.__name__: <14} descr.:"
+                report2 = f"{str(mod.product_descr()): <38} product_id: {mod.pr_id()}"
+                print(f"    {report1}{report2}")
+        # print(f"    {'ProductIDs:': <13}{self.prids}")
 
         print("----------------")

--- a/src/pyairios/models/vmd_02rps78.py
+++ b/src/pyairios/models/vmd_02rps78.py
@@ -87,7 +87,7 @@ class Reg(RegisterAddress):  # only override or add differences in VMD_BASE?
     FREE_VENTILATION_COOLING_OFFSET = 42015
 
 
-class NodeData(AiriosDeviceData):
+class DeviceData(AiriosDeviceData):
     """VMD-02RPS78 node data."""
 
     error_code: Result[VMDErrorCode] | None
@@ -651,10 +651,10 @@ class Node(VmdBase):
             self.regmap[Reg.FAN_SPEED_AWAY_EXHAUST], value, self.slave_id
         )
 
-    async def fetch_node_data(self) -> NodeData:  # pylint: disable=duplicate-code
+    async def fetch_node_data(self) -> DeviceData:  # pylint: disable=duplicate-code
         """Fetch all controller data at once."""
 
-        return NodeData(
+        return DeviceData(
             slave_id=self.slave_id,
             rf_address=await _safe_fetch(self.node_rf_address),
             product_id=await _safe_fetch(self.node_product_id),

--- a/src/pyairios/models/vmd_07rps13.py
+++ b/src/pyairios/models/vmd_07rps13.py
@@ -1,0 +1,621 @@
+"""Airios VMD-07RPS13 ClimaRad Ventura V1 controller implementation."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import math
+from typing import List
+
+from pyairios.client import AsyncAiriosModbusClient
+from pyairios.constants import (
+    ValueStatusFlags,
+    ValueStatusSource,
+    VMDBypassPosition,
+    VMDCapabilities,
+    VMDErrorCode,
+    VMDHeater,
+    VMDHeaterStatus,
+    VMDRequestedVentilationSpeed,
+    VMDSensorStatus,
+    VMDTemperature,
+    VMDVentilationMode,
+    VMDVentilationSpeed,
+)
+from pyairios.data_model import AiriosDeviceData
+from pyairios.exceptions import AiriosInvalidArgumentException
+from pyairios.models.vmd_base import VmdBase
+from pyairios.node import _safe_fetch
+from pyairios.registers import (
+    FloatRegister,
+    RegisterAddress,
+    RegisterBase,
+    Result,
+    ResultStatus,
+    U8Register,
+    U16Register,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+# Linking the registers:
+#   Reg:
+#       model set of RF Bridge register addresses, by named address keyword
+#   Data:
+#       model dict of register address + Result type by name (formerly in data_model.py)
+#   Node.vmd_registers:
+#       instance list of register type (size) + name key from Reg + access R/W
+
+
+class Reg(RegisterAddress):  # only override or add differences in VMD_BASE
+    """The Register set for VMD-07RPS13 ClimaRad Ventura V1 controller node."""
+
+    # numbers between "#" are from oem docs
+    # R
+    BYPASS_POSITION = 41015  # 28 # 1, RO, uint8, "Bypass Position"
+    CO2_LEVEL = 41008  # 17 # 1, RO, uint16, "Main Room Exhaust CO2 Level"
+    ERROR_CODE = 41032  # 23 #  1, RO, uint8, "Error Code"
+    FAN_SPEED_EXHAUST = 41019  # 9 # 1, RO, uint8, "Main Room Fan speed Exhaust"
+    FAN_SPEED_SUPPLY = 41020  # 10 # 1, RO, uint8 "Main Room Fan speed Inlet"
+    FILTER_DIRTY = 41017  # 1, RO, uint8, "Filter Dirty"
+    FILTER_DURATION = 41029  # 1, RO, uint16, "Air Filter Time Duration"
+    FILTER_REMAINING_DAYS = 41028  # 1, RO, uint16, "Air Filter Time Remaining"
+    FILTER_REMAINING_PERCENT = 41030  # 1, RO, uint8, "Air Filter Time Percent"
+    FLOW_INLET = 41024  # L=2, RO, float, "Inlet Flow level"
+    FLOW_OUTLET = 41026  # L=2, RO, float, "Outlet Flow level"
+    HUMIDITY_INDOOR = 41007  # 15 # 1, RO, uint8, "Main Room Exhaust Humidity Level"
+    HUMIDITY_OUTDOOR = 41002  # 1, RO, uint8, "Outlet Humidity"
+    INLET_FLOW = 41024  # 2, RO, float, "Inlet Flow level"
+    OUTLET_FLOW = 41026  # 2, RO, float, "Outlet Flow level"
+    POST_HEATER_DEMAND = 41023  # 1, RO, uint8, "Postheater Demand"
+    TEMPERATURE_EXHAUST = 41005  # 12 # L=2, RO, float, "Main Room Exhaust Temperature"
+    TEMPERATURE_INLET = 41003  # L=2, RO, float, "Inlet Temperature"
+    TEMPERATURE_OUTLET = 41000  #  L=2, RO, float, "Outlet Temperature"
+    TEMP_VENT_MODE = 41103  # 1,R, uint8, "Main Room Ventilation Mode"
+    TEMP_VENT_SUB_MODE = 41104  # 1, R, uint8, "Main Room Ventilation Sub Mode"
+    VENT_MODE = 41100  # 1, R, uint8, "Main Room Ventilation Mode"
+    VENT_SUB_MODE = 41101  # 1, R, uint8, "Main Room Ventilation Sub Mode"
+    VENT_SUB_MODE_EXH = 41102  # R, uint8, Main Room Vent. Sub Mode Cont. Exh.
+    # R/W
+    BASIC_VENT_ENABLE = 42000  # 1, RW, uint8, "Basic Ventilation Enable"
+    BASIC_VENT_LEVEL = 42001  # 1, RW, uint8, "Basic Ventilation Level"
+    CO2_CONTROL_SETPOINT = 42011  # 1, RW, uint16, "CO2 Control Setpoint"
+    FILTER_RESET = 41151  # 1, RW, uint8, "Reset Air Filter Timer"
+    OVERRIDE_TIME_MANUAL = 42009  # 115 # RW, uint16 "Temporary Override Duration"
+    PRODUCT_VARIANT = 42010  # 1,RW, uint8, "Product Variant" = 0?
+    REQ_TEMP_VENT_MODE = 41123  # 1,RW, uint8, "Main Room Temp.Ventilation Mode"
+    REQ_TEMP_VENT_SUB_MODE = 41124  # 1, RW, uint8, "Main Room Vent. Sub Mode"
+    # REQ_TEMP_VENT_SUB_MODE_EXH = (41125  # RW, uint8, Main Room Temp. Vent. Sub Mode Cont. Exh.)
+    REQ_VENT_MODE = 41120  # 1,RW, uint8, "Main Room Ventilation Mode"
+    REQ_VENT_SUB_MODE = 41121  # 1, RW, uint8, "Main Room Ventilation Sub Mode"
+    # REQ_VENT_SUB_MODE_EXH = 41122  # 1, R, uint8, "Main Room Vent. Sub Mode Cont. Exh."
+    # ROOM_INSTANCE = 41126  # 1, RW, uint8, "Room instance" send before setting REQ_xxx
+    SET_PERSON_PRESENT = 41150  # 1, RW, uint8, "Set Person Present"
+    SYSTEM_VENT_CONFIG = 42021  # 1, RW, uint8, "System Ventilation Configuration"
+
+
+class NodeData(AiriosDeviceData):
+    """
+    VMD-07RPS13 ClimaRad Ventura V1C/V1D/V1X node data.
+    source: ClimaRad Modbus Registers Specs 2024
+    """
+
+    basic_ventilation_enable: Result[int] | None
+    bypass_position: Result[VMDBypassPosition] | None
+    co2_control_setpoint: Result[int] | None
+    co2_level: Result[int] | None
+    error_code: Result[VMDErrorCode] | None
+    exhaust_air_temperature: Result[VMDTemperature] | None
+    exhaust_fan_speed: Result[int] | None
+    filter_dirty: Result[int] | None
+    filter_remaining_days: Result[int] | None
+    filter_remaining_percent: Result[int] | None
+    indoor_air_temperature: Result[VMDTemperature] | None
+    product_variant: Result[int] | None
+    supply_air_temperature: Result[VMDTemperature] | None
+    supply_fan_speed: Result[int] | None
+    system_ventilation_config: Result[int] | None
+    temp_ventilation_mode: Result[int] | None
+    temp_ventilation_sub_mode: Result[int] | None
+    ventilation_mode: Result[int] | None
+    ventilation_sub_mode: Result[int] | None
+    ventilation_speed: Result[int] | None  # required for HA fan
+
+
+def pr_id() -> int:
+    """
+    Get product_id for model VMD_07RPS13.
+    Named as is to discern from node.product_id register.
+    :return: unique int
+    """
+    return 0x0001C883
+
+
+def product_descr() -> str | tuple[str, ...]:
+    """
+    Get description of product(s) using VMD_07RPS13.
+    Human-readable text, used in e.g. HomeAssistant Binding UI.
+    :return: string or tuple of strings, starting with manufacturer
+    """
+    return "ClimaRad Ventura V1"
+
+
+class Node(VmdBase):
+    """Represents a VMD-07RPS13 Ventura V1 controller node. HACK in client to access WRITE"""
+
+    def __init__(self, slave_id: int, client: AsyncAiriosModbusClient) -> None:
+        """Initialize the VMD-07RPS13 Ventura controller node instance."""
+        super().__init__(slave_id, client)
+        LOGGER.debug("Starting Ventura Node(%s)", slave_id)
+
+        vmd_registers: List[RegisterBase] = [
+            FloatRegister(Reg.TEMPERATURE_EXHAUST, self.read_status),
+            FloatRegister(Reg.TEMPERATURE_INLET, self.read_status),
+            FloatRegister(Reg.TEMPERATURE_OUTLET, self.read_status),
+            # FloatRegister(Reg.TEMPERATURE_SUPPLY, self.read_status),
+            U8Register(Reg.BASIC_VENT_ENABLE, self.read_write_status),
+            U8Register(Reg.BASIC_VENT_LEVEL, self.read_write_status),
+            U8Register(Reg.BYPASS_POSITION, self.read_status),
+            U16Register(Reg.CO2_CONTROL_SETPOINT, self.read_write),
+            U16Register(Reg.CO2_LEVEL, self.read_status),
+            U8Register(Reg.ERROR_CODE, self.read_status),
+            U8Register(Reg.FAN_SPEED_EXHAUST, self.read_status),
+            U8Register(Reg.FAN_SPEED_SUPPLY, self.read_status),
+            U8Register(Reg.FILTER_DIRTY, self.read_status),
+            # U16Register(Reg.FILTER_DURATION, self.read_status),
+            U16Register(Reg.FILTER_REMAINING_DAYS, self.read_status),
+            U8Register(Reg.FILTER_REMAINING_PERCENT, self.read_status),
+            U8Register(Reg.FILTER_RESET, self.write_status),
+            U8Register(Reg.HUMIDITY_INDOOR, self.read_status),
+            U8Register(Reg.HUMIDITY_OUTDOOR, self.read_status),
+            U16Register(Reg.OVERRIDE_TIME_MANUAL, self.read_write),
+            U8Register(Reg.POST_HEATER_DEMAND, self.read_status),
+            U8Register(Reg.PRODUCT_VARIANT, self.read_write_status),  # UINT8?
+            U8Register(Reg.REQ_TEMP_VENT_MODE, self.read_write_status),
+            U8Register(Reg.REQ_TEMP_VENT_SUB_MODE, self.read_write_status),
+            U8Register(Reg.REQ_VENT_MODE, self.read_write_status),
+            U8Register(Reg.REQ_VENT_SUB_MODE, self.read_write_status),
+            # U8Register(Reg.ROOM_INSTANCE, self.read_write_status),
+            U8Register(Reg.SYSTEM_VENT_CONFIG, self.read_write_status),
+            U8Register(Reg.TEMP_VENT_MODE, self.read_status),
+            U8Register(Reg.TEMP_VENT_SUB_MODE, self.read_status),
+            U8Register(Reg.VENT_MODE, self.read_status),
+            U8Register(Reg.VENT_SUB_MODE, self.read_status),
+        ]
+        self._add_registers(vmd_registers)
+
+    # getters and setters
+
+    async def capabilities(self) -> Result[VMDCapabilities] | None:
+        """Get the ventilation unit capabilities.
+        Capabilities register not supported on VMD-07RPS13, so must simulate"""
+        # Ventura capabilities:
+        _caps = VMDCapabilities.NO_CAPABLE  #  | VMDCapabilities.AUTO_MODE_CAPABLE
+        return Result(
+            _caps,
+            ResultStatus(
+                datetime.timedelta(1000), ValueStatusSource.UNKNOWN, ValueStatusFlags.VALID
+            ),
+        )
+
+    async def system_ventilation_configuration(self) -> Result[int]:
+        """Get the system ventilation configuration status."""
+        return await self.client.get_register(self.regmap[Reg.SYSTEM_VENT_CONFIG], self.slave_id)
+
+    async def vent_mode(self) -> Result[int]:
+        """Get the ventilation mode status. 0=Off, 1=Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        # seen: 0 (with temp_vent_mode 3) | 1 = Pause | 2 = On (with vent_sub_mode 48)
+        return await self.client.get_register(self.regmap[Reg.VENT_MODE], self.slave_id)
+
+    async def rq_vent_mode(self) -> Result[int]:
+        """Get the ventilation mode status. 0=Off, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        return await self.client.get_register(self.regmap[Reg.REQ_VENT_MODE], self.slave_id)
+
+    async def set_rq_vent_mode(self, mode: int) -> bool:  # : VMDVentilationMode) -> bool:
+        """Set the ventilation mode. 0=Off, 1=Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        if mode == VMDVentilationMode.UNKNOWN:
+            raise AiriosInvalidArgumentException(f"Invalid ventilation mode {mode}")
+        return await self.client.set_register(self.regmap[Reg.REQ_VENT_MODE], mode, self.slave_id)
+
+    async def rq_vent_sub_mode(self) -> Result[int]:
+        """Get the ventilation mode status. 0=Off/Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        return await self.client.get_register(self.regmap[Reg.REQ_VENT_SUB_MODE], self.slave_id)
+
+    async def set_rq_vent_sub_mode(self, mode: int) -> bool:  # : VMDVentilationMode) -> bool:
+        """Set the ventilation mode. 0=Off/Pause, 48=Auto"""
+        if mode == VMDVentilationMode.UNKNOWN:
+            raise AiriosInvalidArgumentException(f"Invalid ventilation mode {mode}")
+        return await self.client.set_register(
+            self.regmap[Reg.REQ_VENT_SUB_MODE], mode, self.slave_id
+        )
+
+    async def rq_temp_vent_mode(self) -> Result[int]:
+        """Get the temp ventilation mode status. 0=Off, 1=Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        return await self.client.get_register(self.regmap[Reg.REQ_TEMP_VENT_MODE], self.slave_id)
+
+    async def set_rq_temp_vent_mode(self, mode: int) -> bool:  # : VMDVentilationMode) -> bool:
+        """Set the temp ventilation mode. 0=Off, 1=Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        if mode == VMDVentilationMode.UNKNOWN:
+            raise AiriosInvalidArgumentException(f"Invalid ventilation mode {mode}")
+        return await self.client.set_register(
+            self.regmap[Reg.REQ_TEMP_VENT_MODE], mode, self.slave_id
+        )
+
+    async def rq_temp_vent_sub_mode(self) -> Result[int]:
+        """Get the temp ventilation sub mode status. 0=Off/Pause, 201, ..."""
+        return await self.client.get_register(
+            self.regmap[Reg.REQ_TEMP_VENT_SUB_MODE], self.slave_id
+        )
+
+    async def set_rq_temp_vent_sub_mode(self, mode: int) -> bool:  # : VMDVentilationMode) -> bool:
+        """Set the temp ventilation sub mode. 0=Off/Pause, 201, ..."""
+        if mode == VMDVentilationMode.UNKNOWN:
+            raise AiriosInvalidArgumentException(f"Invalid ventilation mode {mode}")
+        return await self.client.set_register(
+            self.regmap[Reg.REQ_TEMP_VENT_SUB_MODE], mode, self.slave_id
+        )
+
+    async def vent_sub_mode(self) -> Result[int]:
+        """Get the ventilation sub mode status."""
+        # seen: 0 | 48
+        return await self.client.get_register(self.regmap[Reg.VENT_SUB_MODE], self.slave_id)
+
+    async def temp_vent_mode(self) -> Result[int]:
+        """Get the temporary ventilation mode status."""
+        # seen: 0 (with Ventilation mode != 0) | 3
+        return await self.client.get_register(self.regmap[Reg.TEMP_VENT_MODE], self.slave_id)
+
+    async def temp_vent_sub_mode(self) -> Result[int]:
+        """Get the temporary ventilation sub mode status."""
+        # seen: 0 (with temp_vent_mode 3) | 201 | 202 | .. | 205
+        return await self.client.get_register(self.regmap[Reg.TEMP_VENT_SUB_MODE], self.slave_id)
+
+    # can't access these 2 entries in register dump
+    # async def room_instance(self) -> Result[int]:
+    #     """Get the room_instance: 1 = Main or 2 = Secondary"""
+    #     return await self.client.get_register(self.regmap[Reg.ROOM_INSTANCE], self.slave_id)
+    #
+    # async def set_room_instance(self, mode: int) -> bool:
+    #     """Set the room_instance: 1 = Main or 2 = Secondary"""
+    #     return await self.client.set_register(
+    #         self.regmap[Reg.ROOM_INSTANCE], mode, self.slave_id
+    #     )
+
+    async def bypass_position(self) -> Result[VMDBypassPosition]:
+        """Get the bypass position."""
+        regdesc = self.regmap[Reg.BYPASS_POSITION]
+        result = await self.client.get_register(regdesc, self.slave_id)
+        error = result.value > 120
+        return Result(VMDBypassPosition(result.value, error), result.status)
+
+    async def basic_vent_enable(self) -> Result[int]:
+        """Get base ventilation enabled."""
+        return await self.client.get_register(self.regmap[Reg.BASIC_VENT_ENABLE], self.slave_id)
+
+    async def set_basic_vent_enable(self, mode: int) -> bool:
+        """Set base ventilation enabled=1/disabled=0."""
+        return await self.client.set_register(
+            self.regmap[Reg.BASIC_VENT_ENABLE], mode, self.slave_id
+        )
+
+    async def basic_vent_level(self) -> Result[int]:
+        """Get base ventilation level."""
+        return await self.client.get_register(self.regmap[Reg.BASIC_VENT_LEVEL], self.slave_id)
+
+    async def set_basic_vent_level(self, level: int) -> bool:
+        """Set the base ventilation level."""
+        return await self.client.set_register(
+            self.regmap[Reg.BASIC_VENT_LEVEL], level, self.slave_id
+        )
+
+    async def ventilation_speed(self) -> Result[VMDVentilationSpeed]:
+        """Get the ventilation unit active speed preset."""
+
+        # Automatic:
+        # Ventilation mode:        2
+        # Ventilation sub mode:    48
+        # Temp. Ventil. mode:      0
+        # Temp. Ventil. sub mode:  0
+        #
+        # Pause:
+        # Ventilation mode:        1
+        # Ventilation sub mode:    0
+        # Temp. Ventil. mode:      1
+        # Temp. Ventil. sub mode:  0
+        #
+        # Manual/temp 1:
+        # Ventilation mode:        0
+        # Ventilation sub mode:    0
+        # Temp. Ventil. mode:      3
+        # Temp. Ventil. sub mode:  201
+        #
+        # Manual/temp 2:
+        # Ventilation mode:        0
+        # Ventilation sub mode:    0
+        # Temp. Ventil. mode:      3
+        # Temp. Ventil. sub mode:  202
+        #
+        # Ventilation mode:        0
+        # Ventilation sub mode:    0
+        # Temp. Ventil. mode:      3
+        # Temp. Ventil. sub mode:  203
+        #
+        # Stand 5 == Boost >>
+        # Ventilation mode:        0
+        # Ventilation sub mode:    0
+        # Temp. Ventil. mode:      3
+        # Temp. Ventil. sub mode:  205
+
+        mode = await self.client.get_register(self.regmap[Reg.VENT_MODE], self.slave_id)
+        man_step = await self.client.get_register(
+            self.regmap[Reg.TEMP_VENT_SUB_MODE], self.slave_id
+        )
+        speed = VMDVentilationSpeed.OFF
+        if mode.value == 2:
+            speed = VMDVentilationSpeed.AUTO
+        elif mode.value == 1:
+            speed = VMDVentilationSpeed.AWAY
+        elif mode.value == 0:
+            if man_step.value <= 202:
+                speed = VMDVentilationSpeed.OVERRIDE_LOW
+            elif man_step.value <= 203:
+                speed = VMDVentilationSpeed.OVERRIDE_MID
+            elif man_step.value <= 205:
+                speed = VMDVentilationSpeed.OVERRIDE_HIGH
+        return Result(speed, mode.status)
+
+    async def set_ventilation_speed(self, speed: VMDRequestedVentilationSpeed) -> bool:
+        """Set the ventilation unit speed (temp 8H) preset."""
+        md = 0  # VMDVentilationSpeed.OFF, PAUSE?
+        if speed == VMDRequestedVentilationSpeed.AUTO:
+            md = 0
+        elif speed == VMDRequestedVentilationSpeed.AWAY:
+            md = 0
+        elif speed == VMDRequestedVentilationSpeed.LOW:
+            md = 202
+        elif speed == VMDRequestedVentilationSpeed.MID:
+            md = 203
+        elif speed == VMDRequestedVentilationSpeed.HIGH:
+            md = 205
+
+        return await self.client.set_register(  # check why no immediate change
+            self.regmap[Reg.REQ_VENT_SUB_MODE], md, self.slave_id
+        )
+
+    async def product_variant(self) -> Result[int]:
+        """Get the product variant."""
+        regdesc = self.regmap[Reg.PRODUCT_VARIANT]
+        return await self.client.get_register(regdesc, self.slave_id)
+
+    async def co2_level(self) -> Result[int]:
+        """Get the CO2 level (in ppm)."""
+        regdesc = self.regmap[Reg.CO2_LEVEL]
+        return await self.client.get_register(regdesc, self.slave_id)
+
+    async def co2_setpoint(self) -> Result[int]:
+        """Get the CO2 control setpoint (in ppm)."""
+        regdesc = self.regmap[Reg.CO2_CONTROL_SETPOINT]
+        return await self.client.get_register(regdesc, self.slave_id)
+
+    async def set_co2_setpoint(self, setpnt: int) -> bool:
+        """Set the CO2 control setpoint (in ppm)."""
+        return await self.client.set_register(
+            self.regmap[Reg.CO2_CONTROL_SETPOINT], setpnt, self.slave_id
+        )
+
+    async def filter_duration(self) -> Result[int]:
+        """Get the filter duration (in days)."""
+        return await self.client.get_register(self.regmap[Reg.FILTER_DURATION], self.slave_id)
+
+    async def filter_remaining_days(self) -> Result[int]:
+        """Get the filter remaining lifetime (in days)."""
+        return await self.client.get_register(self.regmap[Reg.FILTER_REMAINING_DAYS], self.slave_id)
+
+    async def filter_remaining_percent(self) -> Result[int]:
+        """Get the filter remaining lifetime (in %)."""
+        return await self.client.get_register(
+            self.regmap[Reg.FILTER_REMAINING_PERCENT], self.slave_id
+        )
+
+    async def filter_reset(self) -> bool:
+        """Reset the filter dirty status."""
+        return await self.client.set_register(self.regmap[Reg.FILTER_RESET], 0, self.slave_id)
+
+    async def filter_dirty(self) -> Result[int]:
+        """Get the filter dirty status."""
+        return await self.client.get_register(self.regmap[Reg.FILTER_DIRTY], self.slave_id)
+
+    async def error_code(self) -> Result[VMDErrorCode]:
+        """Get the ventilation unit error code."""
+        regdesc = self.regmap[Reg.ERROR_CODE]
+        result = await self.client.get_register(regdesc, self.slave_id)
+        return Result(VMDErrorCode(result.value), result.status)
+
+    async def indoor_humidity(self) -> Result[int]:
+        """Get the indoor humidity (%)"""
+        return await self.client.get_register(self.regmap[Reg.HUMIDITY_INDOOR], self.slave_id)
+
+    async def outdoor_humidity(self) -> Result[int]:
+        """Get the outdoor humidity (%)"""
+        return await self.client.get_register(self.regmap[Reg.HUMIDITY_OUTDOOR], self.slave_id)
+
+    async def exhaust_fan_speed(self) -> Result[int]:
+        """Get the exhaust fan speed (%)"""
+        return await self.client.get_register(self.regmap[Reg.FAN_SPEED_EXHAUST], self.slave_id)
+
+    async def supply_fan_speed(self) -> Result[int]:
+        """Get the supply fan speed (%)"""
+        return await self.client.get_register(self.regmap[Reg.FAN_SPEED_SUPPLY], self.slave_id)
+
+    async def indoor_air_temperature(self) -> Result[VMDTemperature]:
+        """Get the indoor air temperature.
+
+        This is exhaust temperature before the heat exchanger.
+        """
+        regdesc = self.regmap[Reg.TEMPERATURE_EXHAUST]
+        result = await self.client.get_register(regdesc, self.slave_id)
+        if math.isnan(result.value):
+            status = VMDSensorStatus.UNAVAILABLE
+        elif result.value < -273.0:
+            status = VMDSensorStatus.ERROR
+        else:
+            status = VMDSensorStatus.OK
+        return Result(VMDTemperature(round(result.value, 2), status), result.status)
+
+    async def exhaust_air_temperature(self) -> Result[VMDTemperature]:
+        """Get the exhaust air temperature.
+
+        This is the exhaust temperature after the heat exchanger.
+        """
+        regdesc = self.regmap[Reg.TEMPERATURE_OUTLET]
+        result = await self.client.get_register(regdesc, self.slave_id)
+        if math.isnan(result.value):
+            status = VMDSensorStatus.UNAVAILABLE
+        elif result.value < -273.0:
+            status = VMDSensorStatus.ERROR
+        else:
+            status = VMDSensorStatus.OK
+        return Result(VMDTemperature(round(result.value, 2), status), result.status)
+
+    async def supply_air_temperature(self) -> Result[VMDTemperature]:
+        """Get the supply air temperature.
+
+        This is the supply temperature after the heat exchanger.
+        """
+        regdesc = self.regmap[Reg.TEMPERATURE_EXHAUST]
+        result = await self.client.get_register(regdesc, self.slave_id)
+        if math.isnan(result.value):
+            status = VMDSensorStatus.UNAVAILABLE
+        elif result.value < -273.0:
+            status = VMDSensorStatus.ERROR
+        else:
+            status = VMDSensorStatus.OK
+        return Result(VMDTemperature(round(result.value, 2), status), result.status)
+
+    async def postheater(self) -> Result[VMDHeater]:
+        """Get the postheater level."""
+        regdesc = self.regmap[Reg.POST_HEATER_DEMAND]
+        result = await self.client.get_register(regdesc, self.slave_id)
+        status = VMDHeaterStatus.UNAVAILABLE if result.value == 0xEF else VMDHeaterStatus.OK
+        return Result(VMDHeater(result.value, status), result.status)
+
+    async def fetch_node_data(self) -> NodeData:  # pylint: disable=duplicate-code
+        """Fetch all controller data at once."""
+
+        return NodeData(
+            slave_id=self.slave_id,
+            # node data from pyairios node
+            rf_address=await _safe_fetch(self.node_rf_address),
+            product_id=await _safe_fetch(self.node_product_id),
+            sw_version=await _safe_fetch(self.node_software_version),
+            product_name=await _safe_fetch(self.node_product_name),
+            # device data
+            rf_comm_status=await _safe_fetch(self.node_rf_comm_status),
+            battery_status=await _safe_fetch(self.node_battery_status),
+            fault_status=await _safe_fetch(self.node_fault_status),
+            bound_status=await _safe_fetch(self.device_bound_status),
+            value_error_status=await _safe_fetch(self.device_value_error_status),
+            # VMD-07RPS13 data
+            product_variant=await _safe_fetch(self.product_variant),
+            error_code=await _safe_fetch(self.error_code),
+            system_ventilation_config=await _safe_fetch(self.system_ventilation_configuration),
+            ventilation_mode=await _safe_fetch(self.vent_mode),
+            ventilation_sub_mode=await _safe_fetch(self.vent_sub_mode),
+            # ventilation_sub_mode_exh=await _safe_fetch(self.vent_sub_mode_exh),  # failed
+            temp_ventilation_mode=await _safe_fetch(self.temp_vent_mode),
+            temp_ventilation_sub_mode=await _safe_fetch(self.temp_vent_sub_mode),
+            # temp_ventilation_sub_mode_exh=await _safe_fetch(self.temp_vent_sub_mode_exh), # failed
+            exhaust_fan_speed=await _safe_fetch(self.exhaust_fan_speed),
+            supply_fan_speed=await _safe_fetch(self.supply_fan_speed),
+            indoor_air_temperature=await _safe_fetch(self.indoor_air_temperature),
+            exhaust_air_temperature=await _safe_fetch(self.exhaust_air_temperature),
+            supply_air_temperature=await _safe_fetch(self.supply_air_temperature),
+            filter_dirty=await _safe_fetch(self.filter_dirty),
+            filter_remaining_days=await _safe_fetch(self.filter_remaining_days),
+            filter_remaining_percent=await _safe_fetch(self.filter_remaining_percent),
+            bypass_position=await _safe_fetch(self.bypass_position),
+            basic_ventilation_enable=await _safe_fetch(self.basic_vent_enable),
+            co2_level=await _safe_fetch(self.co2_level),
+            co2_control_setpoint=await _safe_fetch(self.co2_setpoint),
+            ventilation_speed=await _safe_fetch(self.ventilation_speed),
+        )
+
+    async def print_data(self) -> None:
+        """
+        Print labels + states for this particular model, including VMD base fields, in CLI.
+
+        :return: no confirmation, outputs to serial monitor
+        """
+
+        res = await self.fetch_node_data()  # customised per model
+
+        super().print_base_data(res)
+
+        print("VMD-07RPS13 data")
+        print("----------------")
+        print(f"    {'Product Variant:': <25}{res['product_variant']}")
+        print(f"    {'Error code:': <25}{res['error_code']}")
+        print("")
+        print(f"    {'Ventilation mode:': <25}{res['ventilation_mode']}")
+        print(f"    {'Ventilation sub mode:': <25}{res['ventilation_sub_mode']}")
+        print(f"    {'Temp. Ventil. mode:': <25}{res['temp_ventilation_mode']}")
+        print(f"    {'Temp. Ventil. sub mode:': <25}{res['temp_ventilation_sub_mode']}")
+        #
+        print(
+            f"    {'Supply fan speed:': <25}{res['supply_fan_speed']}% "
+            # f"({res['supply_fan_rpm']} RPM)"
+        )
+        print(
+            f"    {'Exhaust fan speed:': <25}{res['exhaust_fan_speed']}% "
+            # f"({res['exhaust_fan_rpm']} RPM)"
+        )
+
+        print(f"    {'Indoor temperature:': <25}{res['indoor_air_temperature']}")
+        # print(f"    {'Outdoor temperature:': <25}{res['outdoor_air_temperature']}")
+        print(f"    {'Exhaust temperature:': <25}{res['exhaust_air_temperature']}")
+        print(f"    {'Supply temperature:': <25}{res['supply_air_temperature']}")
+
+        print(f"    {'CO2 level:':<40}{res['co2_level']} ppm")
+
+        print(f"    {'Filter dirty:': <25}{res['filter_dirty']}")
+        print(f"    {'Filter remaining days:': <25}{res['filter_remaining_days']} days")
+        print(f"    {'Filter remaining perc.:': <25}{res['filter_remaining_percent']}%")
+
+        print(
+            f"    {'Bypass position:': <25}{'Open ' if res == 1 else 'Closed '}{
+                res['bypass_position']
+            }"
+        )
+        print(f"    {'Base ventil. enabled:': <25}{res['basic_ventilation_enable']}")
+
+        # print(f"    {'Postheater:': <25}{res['postheater']}")
+        # print("")
+
+        # print(f"    {'Preset speeds':<25}{'Supply':<10}{'Exhaust':<10}")
+        # print(f"    {'-------------':<25}")
+        # print(
+        #     f"    {'High':<25}{str(res['preset_high_fan_speed_supply']) + ' %':<10}"
+        #     f"{str(res['preset_high_fan_speed_exhaust']) + ' %':<10}"
+        # )
+        # print(
+        #     f"    {'Mid':<25}{str(res['preset_medium_fan_speed_supply']) + ' %':<10}"
+        #     f"{str(res['preset_medium_fan_speed_exhaust']) + ' %':<10}"
+        # )
+        # print(
+        #     f"    {'Low':<25}{str(res['preset_low_fan_speed_supply']) + ' %':<10}"
+        #     f"{str(res['preset_low_fan_speed_exhaust']) + ' %':<10}"
+        # )
+        # print(
+        #     f"    {'Standby':<25}{str(res['preset_standby_fan_speed_supply']) + ' %':<10}"
+        #     f"{str(res['preset_standby_fan_speed_exhaust']) + ' %':<10}"
+        # )
+        print("")
+
+        print("    Setpoints")
+        print("    ---------")
+        print(f"    {'CO2 control setpoint:':<40}{res['co2_control_setpoint']} ppm")
+        # print(
+        #     f"    {'Free ventilation cooling offset:':<40}"
+        #     f"{res['free_ventilation_cooling_offset']} K"
+        # )

--- a/src/pyairios/models/vmd_07rps13.py
+++ b/src/pyairios/models/vmd_07rps13.py
@@ -509,7 +509,7 @@ class Node(VmdBase):
 
         This is the supply temperature after the heat exchanger.
         """
-        regdesc = self.regmap[Reg.TEMPERATURE_EXHAUST]
+        regdesc = self.regmap[Reg.TEMPERATURE_INLET]
         result = await self.client.get_register(regdesc, self.slave_id)
         if math.isnan(result.value):
             status = VMDSensorStatus.UNAVAILABLE

--- a/src/pyairios/models/vmd_07rps13.py
+++ b/src/pyairios/models/vmd_07rps13.py
@@ -28,6 +28,7 @@ from pyairios.models.vmd_base import VmdBase
 from pyairios.node import _safe_fetch
 from pyairios.registers import (
     FloatRegister,
+    RegisterAccess,
     RegisterAddress,
     RegisterBase,
     Result,
@@ -150,38 +151,62 @@ class Node(VmdBase):
         LOGGER.debug("Starting Ventura Node(%s)", slave_id)
 
         vmd_registers: List[RegisterBase] = [
-            FloatRegister(Reg.TEMPERATURE_EXHAUST, self.read_status),
-            FloatRegister(Reg.TEMPERATURE_INLET, self.read_status),
-            FloatRegister(Reg.TEMPERATURE_OUTLET, self.read_status),
-            # FloatRegister(Reg.TEMPERATURE_SUPPLY, self.read_status),
-            U8Register(Reg.BASIC_VENT_ENABLE, self.read_write_status),
-            U8Register(Reg.BASIC_VENT_LEVEL, self.read_write_status),
-            U8Register(Reg.BYPASS_POSITION, self.read_status),
-            U16Register(Reg.CO2_CONTROL_SETPOINT, self.read_write),
-            U16Register(Reg.CO2_LEVEL, self.read_status),
-            U8Register(Reg.ERROR_CODE, self.read_status),
-            U8Register(Reg.FAN_SPEED_EXHAUST, self.read_status),
-            U8Register(Reg.FAN_SPEED_SUPPLY, self.read_status),
-            U8Register(Reg.FILTER_DIRTY, self.read_status),
-            # U16Register(Reg.FILTER_DURATION, self.read_status),
-            U16Register(Reg.FILTER_REMAINING_DAYS, self.read_status),
-            U8Register(Reg.FILTER_REMAINING_PERCENT, self.read_status),
-            U8Register(Reg.FILTER_RESET, self.write_status),
-            U8Register(Reg.HUMIDITY_INDOOR, self.read_status),
-            U8Register(Reg.HUMIDITY_OUTDOOR, self.read_status),
-            U16Register(Reg.OVERRIDE_TIME_MANUAL, self.read_write),
-            U8Register(Reg.POST_HEATER_DEMAND, self.read_status),
-            U8Register(Reg.PRODUCT_VARIANT, self.read_write_status),  # UINT8?
-            U8Register(Reg.REQ_TEMP_VENT_MODE, self.read_write_status),
-            U8Register(Reg.REQ_TEMP_VENT_SUB_MODE, self.read_write_status),
-            U8Register(Reg.REQ_VENT_MODE, self.read_write_status),
-            U8Register(Reg.REQ_VENT_SUB_MODE, self.read_write_status),
-            # U8Register(Reg.ROOM_INSTANCE, self.read_write_status),
-            U8Register(Reg.SYSTEM_VENT_CONFIG, self.read_write_status),
-            U8Register(Reg.TEMP_VENT_MODE, self.read_status),
-            U8Register(Reg.TEMP_VENT_SUB_MODE, self.read_status),
-            U8Register(Reg.VENT_MODE, self.read_status),
-            U8Register(Reg.VENT_SUB_MODE, self.read_status),
+            FloatRegister(Reg.TEMPERATURE_EXHAUST, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            FloatRegister(Reg.TEMPERATURE_INLET, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            FloatRegister(Reg.TEMPERATURE_OUTLET, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            # FloatRegister(Reg.TEMPERATURE_SUPPLY, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(
+                Reg.BASIC_VENT_ENABLE,
+                (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS),
+            ),
+            U8Register(
+                Reg.BASIC_VENT_LEVEL,
+                (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS),
+            ),
+            U8Register(Reg.BYPASS_POSITION, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U16Register(Reg.CO2_CONTROL_SETPOINT, (RegisterAccess.READ | RegisterAccess.WRITE)),
+            U16Register(Reg.CO2_LEVEL, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(Reg.ERROR_CODE, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(Reg.FAN_SPEED_EXHAUST, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(Reg.FAN_SPEED_SUPPLY, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(Reg.FILTER_DIRTY, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            # U16Register(Reg.FILTER_DURATION, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U16Register(Reg.FILTER_REMAINING_DAYS, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(Reg.FILTER_REMAINING_PERCENT, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(Reg.FILTER_RESET, (RegisterAccess.WRITE | RegisterAccess.STATUS)),
+            U8Register(Reg.HUMIDITY_INDOOR, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(Reg.HUMIDITY_OUTDOOR, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U16Register(Reg.OVERRIDE_TIME_MANUAL, (RegisterAccess.READ | RegisterAccess.WRITE)),
+            U8Register(Reg.POST_HEATER_DEMAND, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(
+                Reg.PRODUCT_VARIANT,
+                (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS),
+            ),  # UINT8?
+            U8Register(
+                Reg.REQ_TEMP_VENT_MODE,
+                (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS),
+            ),
+            U8Register(
+                Reg.REQ_TEMP_VENT_SUB_MODE,
+                (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS),
+            ),
+            U8Register(
+                Reg.REQ_VENT_MODE,
+                (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS),
+            ),
+            U8Register(
+                Reg.REQ_VENT_SUB_MODE,
+                (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS),
+            ),
+            # U8Register(Reg.ROOM_INSTANCE, (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS)),
+            U8Register(
+                Reg.SYSTEM_VENT_CONFIG,
+                (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS),
+            ),
+            U8Register(Reg.TEMP_VENT_MODE, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(Reg.TEMP_VENT_SUB_MODE, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(Reg.VENT_MODE, (RegisterAccess.READ | RegisterAccess.STATUS)),
+            U8Register(Reg.VENT_SUB_MODE, (RegisterAccess.READ | RegisterAccess.STATUS)),
         ]
         self._add_registers(vmd_registers)
 

--- a/src/pyairios/models/vmd_07rps13.py
+++ b/src/pyairios/models/vmd_07rps13.py
@@ -96,7 +96,7 @@ class Reg(RegisterAddress):  # only override or add differences in VMD_BASE
     SYSTEM_VENT_CONFIG = 42021  # 1, RW, uint8, "System Ventilation Configuration"
 
 
-class NodeData(AiriosDeviceData):
+class DeviceData(AiriosDeviceData):
     """
     VMD-07RPS13 ClimaRad Ventura V1C/V1D/V1X node data.
     source: ClimaRad Modbus Registers Specs 2024
@@ -526,10 +526,10 @@ class Node(VmdBase):
         status = VMDHeaterStatus.UNAVAILABLE if result.value == 0xEF else VMDHeaterStatus.OK
         return Result(VMDHeater(result.value, status), result.status)
 
-    async def fetch_node_data(self) -> NodeData:  # pylint: disable=duplicate-code
+    async def fetch_node_data(self) -> DeviceData:  # pylint: disable=duplicate-code
         """Fetch all controller data at once."""
 
-        return NodeData(
+        return DeviceData(
             slave_id=self.slave_id,
             # node data from pyairios node
             rf_address=await _safe_fetch(self.node_rf_address),

--- a/src/pyairios/models/vmd_07rps13.py
+++ b/src/pyairios/models/vmd_07rps13.py
@@ -198,7 +198,8 @@ class Node(VmdBase):
                 Reg.REQ_VENT_SUB_MODE,
                 (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS),
             ),
-            # U8Register(Reg.ROOM_INSTANCE, (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS)),
+            # U8Register(Reg.ROOM_INSTANCE,
+            #      (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS)),
             U8Register(
                 Reg.SYSTEM_VENT_CONFIG,
                 (RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS),

--- a/src/pyairios/models/vmd_base.py
+++ b/src/pyairios/models/vmd_base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 from dataclasses import dataclass, field
 
-from pyairios.constants import VMDCapabilities, ValueStatusSource, ValueStatusFlags
+from pyairios.constants import ValueStatusFlags, ValueStatusSource, VMDCapabilities
 from pyairios.device import AiriosDevice
 from pyairios.registers import (
     RegisterAddress,
@@ -19,9 +19,9 @@ class VMDPresetFansSpeeds:
     """Preset fan speeds."""
 
     # this must load from vmd_base to prevent None error
-    exhaust_fan_speed: Result[int] = field(default=Result(-1))
+    exhaust_fan_speed: Result[int] = field()
     """Exhaust fan speed (%)"""
-    supply_fan_speed: Result[int] = field(default=Result(-1))
+    supply_fan_speed: Result[int] = field()
     """Supply fan speed (%)"""
 
     def __post_init__(self):

--- a/src/pyairios/models/vmd_base.py
+++ b/src/pyairios/models/vmd_base.py
@@ -1,0 +1,107 @@
+"""Airios VMD-BASE controller implementation."""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass, field
+
+from pyairios.constants import VMDCapabilities, ValueStatusSource, ValueStatusFlags
+from pyairios.device import AiriosDevice
+from pyairios.registers import (
+    RegisterAddress,
+    Result,
+    ResultStatus,
+)
+
+
+@dataclass
+class VMDPresetFansSpeeds:
+    """Preset fan speeds."""
+
+    # this must load from vmd_base to prevent None error
+    exhaust_fan_speed: Result[int] = field(default_factory=int)
+    """Exhaust fan speed (%)"""
+    supply_fan_speed: Result[int] = field(default_factory=int)
+    """Supply fan speed (%)"""
+
+    def __post_init__(self):
+        if self.exhaust_fan_speed is None:
+            self.exhaust_fan_speed = Result(-1)
+        if self.supply_fan_speed is None:
+            self.supply_fan_speed = Result(-1)
+
+
+class Reg(RegisterAddress):
+    """Register set for VMD-BASE controller node."""
+
+
+def pr_id() -> int:
+    """
+    Get product_id for model VMD- models.
+    Named as is to discern from node.product_id register.
+    :return: unique int
+    """
+    # base class, should not be called
+    return 0x0
+
+
+def product_descr() -> str | tuple[str, ...]:
+    """
+    Get description of product(s) using VMD_xxxx.
+    Human-readable text, used in e.g. HomeAssistant Binding UI.
+    :return: string or tuple of strings, starting with manufacturer
+    """
+    # base class, should not be called
+    return "-"
+
+
+class VmdBase(AiriosDevice):
+    """Base class for VMD-xxx controller nodes."""
+
+    # no VMD-common registers found, leave here as example for new models that do
+    # def __init__(self, slave_id: int, client: AsyncAiriosModbusClient) -> None:
+    #     """Initialize the VMD-x controller node instance."""
+    #     super().__init__(slave_id, client)
+
+    #     vmd_registers: List[RegisterBase] = [
+    #         U16Register(Reg.CURRENT_VENTILATION_SPEED, RegisterAccess.READ_STATUS),
+    #         ...
+    #     ]
+    #     self._add_registers(vmd_registers)
+
+    async def capabilities(self) -> Result[VMDCapabilities] | None:
+        """Get the ventilation unit capabilities.
+        If Capabilities register not supported on model, must simulate"""
+        # not all fans support capabilities register call, must return basics
+        _caps = VMDCapabilities.NO_CAPABLE
+        return Result(
+            _caps,
+            ResultStatus(
+                datetime.timedelta(1000), ValueStatusSource.UNKNOWN, ValueStatusFlags.VALID
+            ),
+        )
+
+    def print_base_data(self, res) -> None:
+        """
+        Print shared VMD labels + states, in CLI.
+
+        :return: no confirmation, outputs to serial monitor
+        """
+        print("Node data")
+        print("---------")
+        print(f"    {'Product ID:': <25}{res['product_id']} (0x{int(res['product_id'].value):08X})")
+        print(f"    {'Product Name:': <25}{res['product_name']}")
+        print(f"    {'Software version:': <25}{res['sw_version']}")
+        print(f"    {'RF address:': <25}{res['rf_address']}")
+        print("")
+
+        print("Device data")
+        print("---------")
+        print(f"    {'RF comm status:': <25}{res['rf_comm_status']}")
+        print(f"    {'Battery status:': <25}{res['battery_status']}")
+        print(f"    {'Fault status:': <25}{res['fault_status']}")
+        print(f"    {'Bound status:': <25}{res['bound_status']}")
+        print(f"    {'Value error status:': <25}{res['value_error_status']}")
+        print("")
+
+        print("----------------")

--- a/src/pyairios/models/vmd_base.py
+++ b/src/pyairios/models/vmd_base.py
@@ -89,7 +89,7 @@ class VmdBase(AiriosDevice):
         """
         print("Node data")
         print("---------")
-        print(f"    {'Product ID:': <25}{res['product_id']} (0x{int(res['product_id'].value):08X})")
+        print(f"    {'Product ID:': <25}{res['product_id']} (0x{res['product_id']:08X})")
         print(f"    {'Product Name:': <25}{res['product_name']}")
         print(f"    {'Software version:': <25}{res['sw_version']}")
         print(f"    {'RF address:': <25}{res['rf_address']}")

--- a/src/pyairios/models/vmd_base.py
+++ b/src/pyairios/models/vmd_base.py
@@ -19,9 +19,9 @@ class VMDPresetFansSpeeds:
     """Preset fan speeds."""
 
     # this must load from vmd_base to prevent None error
-    exhaust_fan_speed: Result[int] = field(default_factory=int)
+    exhaust_fan_speed: Result[int] = field(default=Result(-1))
     """Exhaust fan speed (%)"""
-    supply_fan_speed: Result[int] = field(default_factory=int)
+    supply_fan_speed: Result[int] = field(default=Result(-1))
     """Supply fan speed (%)"""
 
     def __post_init__(self):

--- a/src/pyairios/models/vmn_05lm02.py
+++ b/src/pyairios/models/vmn_05lm02.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+import re
 from typing import List
 
 from pyairios.client import AsyncAiriosModbusClient
 from pyairios.constants import VMDRequestedVentilationSpeed
-from pyairios.data_model import VMN05LM02Data
+from pyairios.data_model import AiriosDeviceData
 from pyairios.device import AiriosDevice
+from pyairios.node import _safe_fetch
 from pyairios.registers import (
     RegisterAccess,
     RegisterAddress,
@@ -16,6 +19,8 @@ from pyairios.registers import (
     U16Register,
 )
 
+LOGGER = logging.getLogger(__name__)
+
 
 class Reg(RegisterAddress):
     """Register set for VMN-05LM02 remote node."""
@@ -23,12 +28,37 @@ class Reg(RegisterAddress):
     REQUESTED_VENTILATION_SPEED = 41000
 
 
-class VMN05LM02(AiriosDevice):
-    """Represents a VMN-05LM02 remote node."""
+class NodeData(AiriosDeviceData):
+    """VMN-05LM02 remote node data."""
+
+    requested_ventilation_speed: Result[VMDRequestedVentilationSpeed] | None
+
+
+def pr_id() -> int:
+    """
+    Get product_id for model VMN_05LM02.
+    Named as is to discern from node.product_id register.
+    :return: unique int
+    """
+    return 0x0001C83E
+
+
+def product_descr() -> str | tuple[str, ...]:
+    """
+    Get description of product(s) using VMN_05LM02.
+    Human-readable text, used in e.g. HomeAssistant Binding UI.
+    :return: string or tuple of strings, starting with manufacturer
+    """
+    return "Siber 4 button Remote"
+
+
+class Node(AiriosDevice):
+    """Represents a VMN-05LM02 Siber 4 button remote node."""
 
     def __init__(self, slave_id: int, client: AsyncAiriosModbusClient) -> None:
         """Initialize the VMN-05LM02 node instance."""
         super().__init__(slave_id, client)
+        LOGGER.debug("Starting Siber Remote Node(%s)", slave_id)
         vmn_registers: List[RegisterBase] = [
             U16Register(
                 Reg.REQUESTED_VENTILATION_SPEED, RegisterAccess.READ | RegisterAccess.STATUS
@@ -37,7 +67,8 @@ class VMN05LM02(AiriosDevice):
         self._add_registers(vmn_registers)
 
     def __str__(self) -> str:
-        return f"VMN-05LM02@{self.slave_id}"
+        prompt = str(re.sub(r"_", "-", self.__module__.upper()))
+        return f"{prompt}@{self.slave_id}"
 
     async def requested_ventilation_speed(self) -> Result[VMDRequestedVentilationSpeed]:
         """Get the requested ventilation speed."""
@@ -45,19 +76,49 @@ class VMN05LM02(AiriosDevice):
         result = await self.client.get_register(regdesc, self.slave_id)
         return Result(VMDRequestedVentilationSpeed(result.value), result.status)
 
-    async def fetch_vmn_data(self) -> VMN05LM02Data:  # pylint: disable=duplicate-code
+    async def fetch_node_data(self) -> NodeData:  # pylint: disable=duplicate-code
         """Get the node device data at once."""
 
-        return VMN05LM02Data(
+        return NodeData(
             slave_id=self.slave_id,
-            rf_address=await self._safe_fetch(self.node_rf_address),
-            product_id=await self._safe_fetch(self.node_product_id),
-            sw_version=await self._safe_fetch(self.node_software_version),
-            product_name=await self._safe_fetch(self.node_product_name),
-            rf_comm_status=await self._safe_fetch(self.node_rf_comm_status),
-            battery_status=await self._safe_fetch(self.node_battery_status),
-            fault_status=await self._safe_fetch(self.node_fault_status),
-            bound_status=await self._safe_fetch(self.device_bound_status),
-            value_error_status=await self._safe_fetch(self.device_value_error_status),
-            requested_ventilation_speed=await self._safe_fetch(self.requested_ventilation_speed),
+            rf_address=await _safe_fetch(self.node_rf_address),
+            product_id=await _safe_fetch(self.node_product_id),
+            sw_version=await _safe_fetch(self.node_software_version),
+            product_name=await _safe_fetch(self.node_product_name),
+            rf_comm_status=await _safe_fetch(self.node_rf_comm_status),
+            battery_status=await _safe_fetch(self.node_battery_status),
+            fault_status=await _safe_fetch(self.node_fault_status),
+            bound_status=await _safe_fetch(self.device_bound_status),
+            value_error_status=await _safe_fetch(self.device_value_error_status),
+            requested_ventilation_speed=await _safe_fetch(self.requested_ventilation_speed),
         )
+
+    async def print_data(self) -> None:
+        """
+        Print labels + states for this particular model in CLI.
+
+        :return: no confirmation, outputs to serial monitor
+        """
+        res = await self.fetch_node_data()  # customised per model
+
+        print("Node data")
+        print("---------")
+        print(f"    {'Product ID:': <25}{res['product_id']} (0x{int(res['product_id'].value):08X})")
+        print(f"    {'Product Name:': <25}{res['product_name']}")
+        print(f"    {'Software version:': <25}{res['sw_version']}")
+        print(f"    {'RF address:': <25}{res['rf_address']}")
+        print("")
+
+        print("Device data")
+        print("---------")
+        print(f"    {'RF comm status:': <25}{res['rf_comm_status']}")
+        print(f"    {'Battery status:': <25}{res['battery_status']}")
+        print(f"    {'Fault status:': <25}{res['fault_status']}")
+        print(f"    {'Bound status:': <25}{res['bound_status']}")
+        print(f"    {'Value error status:': <25}{res['value_error_status']}")
+        print("")
+
+        # super().print_data(res)  # no superclass set up for VMN yet
+        print("VMN-05LM02 data")
+        print("----------------")
+        print(f"    {'Requested ventilation speed:': <40}{res['requested_ventilation_speed']}")

--- a/src/pyairios/models/vmn_05lm02.py
+++ b/src/pyairios/models/vmn_05lm02.py
@@ -28,7 +28,7 @@ class Reg(RegisterAddress):
     REQUESTED_VENTILATION_SPEED = 41000
 
 
-class NodeData(AiriosDeviceData):
+class DeviceData(AiriosDeviceData):
     """VMN-05LM02 remote node data."""
 
     requested_ventilation_speed: Result[VMDRequestedVentilationSpeed] | None
@@ -76,10 +76,10 @@ class Node(AiriosDevice):
         result = await self.client.get_register(regdesc, self.slave_id)
         return Result(VMDRequestedVentilationSpeed(result.value), result.status)
 
-    async def fetch_node_data(self) -> NodeData:  # pylint: disable=duplicate-code
+    async def fetch_node_data(self) -> DeviceData:  # pylint: disable=duplicate-code
         """Get the node device data at once."""
 
-        return NodeData(
+        return DeviceData(
             slave_id=self.slave_id,
             rf_address=await _safe_fetch(self.node_rf_address),
             product_id=await _safe_fetch(self.node_product_id),

--- a/src/pyairios/models/vmn_05lm02.py
+++ b/src/pyairios/models/vmn_05lm02.py
@@ -103,7 +103,7 @@ class Node(AiriosDevice):
 
         print("Node data")
         print("---------")
-        print(f"    {'Product ID:': <25}{res['product_id']} (0x{int(res['product_id'].value):08X})")
+        print(f"    {'Product ID:': <25}{res['product_id']} (0x{res['product_id']:08X})")
         print(f"    {'Product Name:': <25}{res['product_name']}")
         print(f"    {'Software version:': <25}{res['sw_version']}")
         print(f"    {'RF address:': <25}{res['rf_address']}")

--- a/src/pyairios/node.py
+++ b/src/pyairios/node.py
@@ -75,7 +75,7 @@ class AiriosNode:
 
     def __init__(self, slave_id: int, client: AsyncAiriosModbusClient) -> None:
         """Initialize the node class instance."""
-        LOGGER.debug("Init AiriosNode")
+        LOGGER.debug("Init AiriosNode@%s", slave_id)
 
         self.client = client
         self.slave_id = int(slave_id)
@@ -109,7 +109,7 @@ class AiriosNode:
             U32Register(Reg.FAULT_HISTORY_STATUS_INFO, RegisterAccess.READ),
             U16Register(Reg.FAULT_HISTORY_COMM_STATUS, RegisterAccess.READ),
         ]
-        LOGGER.debug("Add node_registers")
+        LOGGER.debug("Add node registers")
         self._add_registers(node_registers)
 
     def _add_registers(self, reglist: List[RegisterBase]):
@@ -165,7 +165,7 @@ class AiriosNode:
         """Get the received product ID.
 
         This is the value received from the bound node. If it does not match register
-        NODE_PRODUCT_ID, a wrong product is bound.
+        PRODUCT_ID, a wrong product is bound.
         """
         return await self.client.get_register(self.regmap[Reg.RECEIVED_PRODUCT_ID], self.slave_id)
 
@@ -223,7 +223,7 @@ class AiriosNode:
             age = datetime.timedelta(minutes=r.value)
             rec = RFStats.Record(
                 device_id=device_id,
-                averate=average,
+                average=average,
                 stddev=stddev,
                 minimum=minimum,
                 maximum=maximum,

--- a/src/pyairios/registers.py
+++ b/src/pyairios/registers.py
@@ -73,12 +73,12 @@ class StringRegister(RegisterBase[str]):
     def decode(self, registers: list[int]) -> str:
         """Decode register bytes to value."""
 
-        def registers_to_bytearray(registers: list[int]) -> bytearray:
+        def registers_to_bytearray(_registers: list[int]) -> bytearray:
             """Convert registers to bytes."""
-            b = bytearray()
-            for x in registers:
-                b.extend(x.to_bytes(2, "big"))
-            return b
+            _b = bytearray()
+            for x in _registers:
+                _b.extend(x.to_bytes(2, "big"))
+            return _b
 
         b = registers_to_bytearray(registers)
 
@@ -112,7 +112,17 @@ class NumberRegister(RegisterBase[T]):
 
     def encode(self, value: T) -> list[int]:
         """Encode value to register bytes."""
-        if isinstance(value, int):
+        if isinstance(
+            value, str
+        ):  # all CLI entries are passed in as str, despite casting in method call
+            try:
+                int_value = int(value)
+                return ModbusClientMixin.convert_to_registers(
+                    int_value, self.datatype, word_order="little"
+                )
+            except AiriosInvalidArgumentException as exc:
+                raise AiriosInvalidArgumentException(f"Entered str {value} not a number") from exc
+        elif isinstance(value, int):
             return ModbusClientMixin.convert_to_registers(value, self.datatype, word_order="little")
         if isinstance(value, (bool, float)):
             return ModbusClientMixin.convert_to_registers(

--- a/src/pyairios/registers.py
+++ b/src/pyairios/registers.py
@@ -138,6 +138,19 @@ class NumberRegister(RegisterBase[T]):
         return ModbusClientMixin.convert_to_registers(reg_value, self.datatype, word_order="little")
 
 
+class U8Register(NumberRegister[int]):
+    """Unsigned 8-bit entry, sent to modbus as UINT16 register."""
+
+    datatype = ModbusClientMixin.DATATYPE.UINT16
+    min = 0
+    max = 2**8 - 1
+
+    def __init__(self, address: RegisterAddress, access: RegisterAccess) -> None:
+        """Initialize the U8Register instance."""
+        description = RegisterDescription(address, 1, access)
+        super().__init__(description)
+
+
 class U16Register(NumberRegister[int]):
     """Unsigned 16-bit register."""
 

--- a/src/pyairios/registers.py
+++ b/src/pyairios/registers.py
@@ -163,6 +163,19 @@ class U8Register(NumberRegister[int]):
         return super().encode(int_value)
 
 
+class U8Register(NumberRegister[int]):
+    """Unsigned 8-bit entry, sent to modbus as UINT16 register."""
+
+    datatype = ModbusClientMixin.DATATYPE.UINT16
+    min = 0
+    max = 2**8 - 1
+
+    def __init__(self, address: RegisterAddress, access: RegisterAccess) -> None:
+        """Initialize the U8Register instance."""
+        description = RegisterDescription(address, 1, access)
+        super().__init__(description)
+
+
 class U16Register(NumberRegister[int]):
     """Unsigned 16-bit register."""
 


### PR DESCRIPTION
Fresh PR on master, replaces #4 

For dynamic model support:
  - Refactor existing models, init, node
  - In BRDG add 3 methods te get models() info ~fields to bridge_data~
  - Add VMD-base, vmd_07rps13 (Ventura)
  - Remove const ProductId enum, replaced by per model product_id()

Add const OffOnMode, U8Register, used in Ventura

For CLI to work:
  - move model print_status() to model files, VMD-base
  - parse entered values from str to int (example: "do_set_co2 800")
 
Left out the Access Flag to IntEnum change