### PR TITLE
Add BRDG-02EM23 Ethernet bridge support (tested on real hardware)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ Binding is only possible when products have the same *OEM code*. The RF bridge h
 
 This library has been tested with the following devices:
 
-* [Siber DF Optima 2](https://www.siberzone.es/descarga/siber-df-optima-2-19170/) ([Airios VMD-02RPS78](https://www.airios.eu/vmd-heat-recovery-unit-controller))
+* [Siber DF Evo 2 / DF Optima 2](https://www.siberzone.es/descarga/siber-df-optima-2-19170/) ([Airios VMD-02RPS78](https://www.airios.eu/vmd-heat-recovery-unit-controller))
 * [Siber 4 button remote](https://www.siberzone.es/descarga/mando-pulsador-inal%C3%81mbrico-4-posiciones-15462/) ([Airios VMN-02LM11](https://www.airios.eu/vmn-02lm11))
 * [ClimaRad Ventura V1X HRU](https://www.climarad.nl/) ([Airios VMD-07RPS13](https://www.airios.eu/vmd-heat-recovery-unit-controller))
 * [Orcon generic](https://www.orcon.nl/) ([Airios VMD-02EM23-2](https://www.airios.eu/vmd-heat-recovery-unit-controller))
+* Siber DFEVORFETH Ethernet bridge ([Airios BRDG-02EM23](https://www.airios.eu/brdg-02em23)), Modbus-TCP
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All of these components communicate over a proprietary RF protocol from Honeywel
 
 There are two bridge models with different interfaces. The [BRDG-02R13](https://www.airios.eu/brdg-02r13) has a RS485 serial interface (Modbus-RTU) and the [BRDG-02EM23](https://www.airios.eu/brdg-02em23) is an Ethernet device (Modbus-TCP).
 
-This library only supports the RS485 model.
+This library supports both models.
 
 ## Working principle
 
@@ -34,6 +34,8 @@ This library has been tested with the following devices:
 
 * [Siber DF Optima 2](https://www.siberzone.es/descarga/siber-df-optima-2-19170/) ([Airios VMD-02RPS78](https://www.airios.eu/vmd-heat-recovery-unit-controller))
 * [Siber 4 button remote](https://www.siberzone.es/descarga/mando-pulsador-inal%C3%81mbrico-4-posiciones-15462/) ([Airios VMN-02LM11](https://www.airios.eu/vmn-02lm11))
+* [ClimaRad Ventura V1X HRU](https://www.climarad.nl/) ([Airios VMD-07RPS13](https://www.airios.eu/vmd-heat-recovery-unit-controller))
+* [Orcon generic](https://www.orcon.eu/) ([Airios VMD-02EM23-2](https://www.airios.eu/vmd-heat-recovery-unit-controller))
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This library has been tested with the following devices:
 * [Siber DF Optima 2](https://www.siberzone.es/descarga/siber-df-optima-2-19170/) ([Airios VMD-02RPS78](https://www.airios.eu/vmd-heat-recovery-unit-controller))
 * [Siber 4 button remote](https://www.siberzone.es/descarga/mando-pulsador-inal%C3%81mbrico-4-posiciones-15462/) ([Airios VMN-02LM11](https://www.airios.eu/vmn-02lm11))
 * [ClimaRad Ventura V1X HRU](https://www.climarad.nl/) ([Airios VMD-07RPS13](https://www.airios.eu/vmd-heat-recovery-unit-controller))
-* [Orcon generic](https://www.orcon.eu/) ([Airios VMD-02EM23-2](https://www.airios.eu/vmd-heat-recovery-unit-controller))
+* [Orcon generic](https://www.orcon.nl/) ([Airios VMD-02EM23-2](https://www.airios.eu/vmd-heat-recovery-unit-controller))
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This library has been tested with the following devices:
 * [Siber DF Evo 2 / DF Optima 2](https://www.siberzone.es/descarga/siber-df-optima-2-19170/) ([Airios VMD-02RPS78](https://www.airios.eu/vmd-heat-recovery-unit-controller))
 * [Siber 4 button remote](https://www.siberzone.es/descarga/mando-pulsador-inal%C3%81mbrico-4-posiciones-15462/) ([Airios VMN-02LM11](https://www.airios.eu/vmn-02lm11))
 * [ClimaRad Ventura V1X HRU](https://www.climarad.nl/) ([Airios VMD-07RPS13](https://www.airios.eu/vmd-heat-recovery-unit-controller))
-* [Orcon generic](https://www.orcon.nl/) ([Airios VMD-02EM23-2](https://www.airios.eu/vmd-heat-recovery-unit-controller))
+* [Orcon generic](https://www.orcon.nl/) ([Airios VMD-15RMS86-2](https://www.airios.eu/vmd-heat-recovery-unit-controller))
 * Siber DFEVORFETH Ethernet bridge ([Airios BRDG-02EM23](https://www.airios.eu/brdg-02em23)), Modbus-TCP
 
 ## Installation

--- a/cli.py
+++ b/cli.py
@@ -552,8 +552,219 @@ class AiriosVMD07RPS13CLI(aiocmd.PromptToolkitCmd):
         pprint.pprint(res)
 
 
-class AiriosBridgeCLI(aiocmd.PromptToolkitCmd):
-    """The bridge CLI interface."""
+class AiriosVMD15RMS86CLI(aiocmd.PromptToolkitCmd):
+    """The VMD15RMS86 CLI interface."""
+
+    vmd: VMD15RMS86
+
+    def __init__(self, vmd: AiriosDevice) -> None:
+        super().__init__()
+        self.prompt = f"[VMD-15RMS86@{vmd.device_id}]>> "
+        self.vmd = cast(VMD15RMS86, vmd)
+
+    async def do_capabilities(self) -> None:
+        """Print the device RF capabilities."""
+        res = await self.vmd.capabilities()
+        print(f"{res.value} ({res.status})")
+
+    async def do_status(self) -> None:  # pylint: disable=too-many-statements
+        """Print the device status."""
+        res = await self.vmd.fetch(with_status=False)
+
+        _print_node_data(res)
+
+        print("VMD-15RMS86 data")
+        print("----------------")
+        print(f"    {'Error code:': <25}{res[vmdp.ERROR_CODE]}")
+
+        print(f"    {'Ventilation speed:': <25}{res[vmdp.CURRENT_VENTILATION_SPEED]}")
+        print(
+            (
+                f"    {'Override remaining time:': <25}"
+                f"{res[vmdp.VENTILATION_SPEED_OVERRIDE_REMAINING_TIME]}"
+            )
+        )
+
+        print(
+            f"    {'Supply fan speed:': <25}{res[vmdp.FAN_SPEED_SUPPLY]}% "
+            f"({res[vmdp.FAN_RPM_SUPPLY]} RPM)"
+        )
+        print(
+            f"    {'Exhaust fan speed:': <25}{res[vmdp.FAN_SPEED_EXHAUST]}% "
+            f"({res[vmdp.FAN_RPM_EXHAUST]} RPM)"
+        )
+
+        print(f"    {'Inlet temperature:': <25}{res[vmdp.TEMPERATURE_INLET]}")
+        print(f"    {'Supply temperature:': <25}{res[vmdp.TEMPERATURE_SUPPLY]}")
+        print(f"    {'Exhaust temperature:': <25}{res[vmdp.TEMPERATURE_EXHAUST]}")
+        print(f"    {'Outlet temperature:': <25}{res[vmdp.TEMPERATURE_OUTLET]}")
+
+        print(f"    {'Filter dirty:': <25}{res[vmdp.FILTER_DIRTY]}")
+        print(f"    {'Filter remaining:': <25}{res[vmdp.FILTER_REMAINING_PERCENT]} %")
+        print(f"    {'Filter duration:': <25}{res[vmdp.FILTER_REMAINING_DAYS]} days")
+
+        print(f"    {'Bypass position:': <25}{res[vmdp.BYPASS_POSITION]}")
+        print(f"    {'Bypass status:': <25}{res[vmdp.BYPASS_STATUS]}")
+        print(f"    {'Bypass mode:': <25}{res[vmdp.BYPASS_MODE]}")
+
+        print(f"    {'Defrost:': <25}{res[vmdp.DEFROST]}")
+        print(f"    {'Preheater:': <25}{res[vmdp.PREHEATER]}")
+        print(f"    {'Postheater:': <25}{res[vmdp.POSTHEATER]}")
+        print("")
+
+        print(f"    {'Preset speeds':<25}{'Supply':<10}{'Exhaust':<10}")
+        print(f"    {'-------------':<25}")
+        print(
+            f"    {'High':<25}{str(res[vmdp.FAN_SPEED_HIGH_SUPPLY]) + ' %':<10}"
+            f"{str(res[vmdp.FAN_SPEED_HIGH_EXHAUST]) + ' %':<10}"
+        )
+        print(
+            f"    {'Mid':<25}{str(res[vmdp.FAN_SPEED_MID_SUPPLY]) + ' %':<10}"
+            f"{str(res[vmdp.FAN_SPEED_MID_EXHAUST]) + ' %':<10}"
+        )
+        print(
+            f"    {'Low':<25}{str(res[vmdp.FAN_SPEED_LOW_SUPPLY]) + ' %':<10}"
+            f"{str(res[vmdp.FAN_SPEED_LOW_EXHAUST]) + ' %':<10}"
+        )
+        print(
+            f"    {'Away':<25}{str(res[vmdp.FAN_SPEED_AWAY_SUPPLY]) + ' %':<10}"
+            f"{str(res[vmdp.FAN_SPEED_AWAY_EXHAUST]) + ' %':<10}"
+        )
+        print("")
+
+        print("    Setpoints")
+        print("    ---------")
+        print(
+            f"    {'Frost protection preheater setpoint:':<40}"
+            f"{res[vmdp.FROST_PROTECTION_PREHEATER_SETPOINT]} ºC"
+        )
+        print(f"    {'Preheater setpoint:': <40}{res[vmdp.PREHEATER_SETPOINT]} ºC")
+        print(
+            (
+                f"    {'Free ventilation setpoint:':<40}"
+                f"{res[vmdp.FREE_VENTILATION_HEATING_SETPOINT]} ºC"
+            )
+        )
+        # print(
+        #     f"    {'Free ventilation cooling offset:':<40}"
+        #     f"{res[vmdp.FREE_VENTILATION_COOLING_OFFSET]} K"
+        # )
+
+    async def do_error_code(self) -> None:
+        """Print the current error code."""
+        res = await self.vmd.error_code()
+        print(f"{res}")
+
+    async def do_ventilation_speed(self) -> None:
+        """Print the current ventilation speed."""
+        res = await self.vmd.ventilation_speed()
+        if res.value in [
+            VMDVentilationSpeed.OVERRIDE_LOW,
+            VMDVentilationSpeed.OVERRIDE_MID,
+            VMDVentilationSpeed.OVERRIDE_HIGH,
+        ]:
+            rem = await self.vmd.override_remaining_time()
+            print(f"{res.value} ({rem.value} min. remaining)")
+        else:
+            print(f"{res}")
+        if res.status is not None:
+            print(f"{res.status}")
+
+    async def do_set_ventilation_speed(self, preset: str) -> None:
+        """Change the ventilation speed."""
+        s = VMDRequestedVentilationSpeed.parse(preset)
+        await self.vmd.set_ventilation_speed(s)
+
+    async def do_set_ventilation_speed_override_time(self, preset: str, minutes: str) -> None:
+        """Change the ventilation speed for a limited time."""
+        s = VMDRequestedVentilationSpeed.parse(preset)
+        await self.vmd.set_ventilation_speed_override_time(s, int(minutes))
+
+    async def do_preset_away_fans_speeds(self):
+        """Print the away preset fan speeds."""
+        res = await self.vmd.preset_away_fans_speed()
+        print(f"{'Supply fan speed:': <25}{res.supply_fan_speed}%")
+        print(f"{'Exhaust fan speed:': <25}{res.exhaust_fan_speed}%")
+
+    async def do_set_preset_away_fans_speeds(self, supply: int, exhaust: int):
+        """Change the away preset fan speeds."""
+        await self.vmd.set_preset_away_fans_speed(int(supply), int(exhaust))
+
+    async def do_preset_low_fans_speeds(self):
+        """Print the low preset fan speeds."""
+        res = await self.vmd.preset_low_fans_speed()
+        print(f"{'Supply fan speed:': <25}{res.supply_fan_speed}%")
+        print(f"{'Exhaust fan speed:': <25}{res.exhaust_fan_speed}%")
+
+    async def do_set_preset_low_fans_speeds(self, supply: int, exhaust: int):
+        """Change the low preset fan speeds."""
+        await self.vmd.set_preset_low_fans_speed(int(supply), int(exhaust))
+
+    async def do_preset_mid_fans_speeds(self):
+        """Print the mid preset fan speeds."""
+        res = await self.vmd.preset_mid_fans_speed()
+        print(f"{'Supply fan speed:': <25}{res.supply_fan_speed}%")
+        print(f"{'Exhaust fan speed:': <25}{res.exhaust_fan_speed}%")
+
+    async def do_set_preset_mid_fans_speeds(self, supply: int, exhaust: int):
+        """Change the mid preset fan speeds."""
+        await self.vmd.set_preset_mid_fans_speed(int(supply), int(exhaust))
+
+    async def do_preset_high_fans_speeds(self):
+        """Print the high preset fan speeds."""
+        res = await self.vmd.preset_high_fans_speed()
+        print(f"{'Supply fan speed:': <25}{res.supply_fan_speed}%")
+        print(f"{'Exhaust fan speed:': <25}{res.exhaust_fan_speed}%")
+
+    async def do_set_preset_high_fans_speeds(self, supply: int, exhaust: int):
+        """Change the high preset fan speeds."""
+        await self.vmd.set_preset_high_fans_speed(int(supply), int(exhaust))
+
+    async def do_bypass_position(self):
+        """Print the bypass position."""
+        res = await self.vmd.bypass_position()
+        print(f"{res}")
+
+    async def do_bypass_status(self):
+        """Print the bypass status."""
+        res = await self.vmd.bypass_status()
+        print(f"{res}")
+
+    async def do_bypass_mode(self):
+        """Print the bypass mode."""
+        res = await self.vmd.bypass_mode()
+        print(f"{res}")
+
+    async def do_set_bypass_mode(self, mode: str):
+        """Change the bypass mode."""
+        v = VMDBypassMode.parse(mode)
+        await self.vmd.set_bypass_mode(v)
+
+    async def do_filter_duration(self):
+        """Print the filter duration."""
+        res = await self.vmd.filter_duration()
+        print(f"{res}")
+
+    async def do_filter_remaining(self):
+        """Print the filter remaining percentage."""
+        r1 = await self.vmd.filter_remaining()
+        r2 = await self.vmd.filter_remaining_days()
+        r3 = await self.vmd.filter_duration()
+        print(f"{r1.value} % ({r2.value} of {r3.value} days)")
+
+    async def do_filter_reset(self):
+        """Reset the filter change timer."""
+        await self.vmd.filter_reset()
+
+    async def do_properties(self, status: bool) -> None:
+        """Print all device properties."""
+        _status = status in (1, "y", "yes")
+        res = await self.vmd.fetch(with_status=_status)
+        pprint.pprint(res)
+
+
+class AiriosSerialBridgeCLI(aiocmd.PromptToolkitCmd):
+    """The Serial bridge CLI interface."""
 
     bridge: BRDG02R13
 
@@ -588,6 +799,10 @@ class AiriosBridgeCLI(aiocmd.PromptToolkitCmd):
 
         if node_info.product_id == ProductId.VMD_02RPS78:
             await AiriosVMD02RPS78CLI(dev).run()
+        elif node_info.product_id == ProductId.VMD_07RPS13:
+            await AiriosVMD07RPS13CLI(dev).run()
+        elif node_info.product_id == ProductId.VMD_15RMS86:
+            await AiriosVMD15RMS86CLI(dev).run()
         elif node_info.product_id == ProductId.VMN_05LM02:
             await AiriosVMN05LM02CLI(dev).run()
         else:
@@ -715,6 +930,174 @@ class AiriosBridgeCLI(aiocmd.PromptToolkitCmd):
         pprint.pprint(res)
 
 
+class AiriosTcpBridgeCLI(aiocmd.PromptToolkitCmd):
+    """The TCP bridge CLI interface."""
+
+    bridge: BRDG02EM23
+
+    def __init__(self, dev: AiriosDevice) -> None:
+        super().__init__()
+        self.prompt = f"[BRDG-02EM23@{dev.device_id}]>> "
+        self.bridge = cast(BRDG02EM23, dev)
+
+    async def do_nodes(self) -> None:
+        """Print the list of bound nodes."""
+        res = await self.bridge.nodes()
+        for n in res:
+            print(f"{n}")
+
+    async def do_node(self, device_id: str) -> None:
+        """Manage a bound node."""
+        nodes = await self.bridge.nodes()
+        node_info = None
+        for n in nodes:
+            if int(device_id) == int(n.modbus_address):
+                node_info = n
+                break
+
+        if node_info is None:
+            raise AiriosIOException(f"Node with address {device_id} not bound")
+
+        dev = await factory.get_device_by_product_id(
+            node_info.product_id,
+            node_info.modbus_address,
+            self.bridge.client,
+        )
+
+        if node_info.product_id == ProductId.VMD_02RPS78:
+            await AiriosVMD02RPS78CLI(dev).run()
+        elif node_info.product_id == ProductId.VMD_07RPS13:
+            await AiriosVMD07RPS13CLI(dev).run()
+        elif node_info.product_id == ProductId.VMD_15RMS86:
+            await AiriosVMD15RMS86CLI(dev).run()
+        elif node_info.product_id == ProductId.VMN_05LM02:
+            await AiriosVMN05LM02CLI(dev).run()
+        else:
+            raise AiriosNotImplemented(f"{node_info.product_id} not implemented")
+
+    async def do_rf_sent_messages(self) -> None:
+        """Print the RF sent messages."""
+        res = await self.bridge.rf_sent_messages()
+        print(f"RF Sent Messages: {res}")
+
+    async def do_modbus_events(self) -> None:
+        """Print the modbus events mode."""
+        res = await self.bridge.modbus_events()
+        print(f"Modbus events: {res}")
+
+    async def do_set_modbus_events(self, mode: str) -> None:
+        """Set the Modbus events mode:
+        'none'   - No Modbus events are generated
+        'bridge' - Modbus function 'bridge event' is sent when a value is changed
+        'node'   - Modbus function 'node event' is sent when a value is changed
+        'data'   - Modbus function 'data event' is sent when a value is changed
+        """
+        value = ModbusEvents.parse(mode)
+        await self.bridge.set_modbus_events(value)
+
+    # no serial config for TCP
+    # async def do_serial_config(self) -> None:
+    #     """Print the serial configuration."""
+    #     res = await self.bridge.serial_config()
+    #     print(f"Serial Config: {res}")
+
+    # async def do_set_serial_config(self, baudrate: int, parity: str, stop_bits: int) -> None:
+    #     """Set the serial configuration.
+    #
+    #     The bridge must be reset to make new settings effective."""
+    #     b = Baudrate.parse(baudrate)
+    #     p = Parity.parse(parity)
+    #     s = StopBits.parse(stop_bits)
+    #     config = SerialConfig(b, p, s)
+    #     if await self.bridge.set_serial_config(config):
+    #         print("Reset the bridge with `reset` command to make new settings effective.")
+
+    async def do_uptime(self) -> None:
+        """Print the device uptime."""
+        res = await self.bridge.power_on_time()
+        print(f"Uptime: {res}")
+
+    async def do_reset(self, factory_reset: bool = False) -> None:
+        """Reset the device."""
+        mode = ResetMode.SOFT_RESET
+        if factory_reset:
+            mode = ResetMode.FACTORY_RESET
+        await self.bridge.reset(mode)
+
+    async def do_unbind(self, device_id) -> None:
+        """Remove a bound node."""
+        device_id = int(device_id)
+        await self.bridge.unbind(device_id)
+
+    async def do_bind_status(self) -> None:
+        """Print bind status."""
+        res = await self.bridge.bind_status()
+        print(f"Bind status: {res}")
+
+    async def do_bind_controller(
+        self, device_id, product_id, product_serial: str | None = None
+    ) -> None:
+        """Bind a new controller."""
+        device_id = int(device_id)
+        pid = ProductId(int(product_id))
+        psn = None
+        if product_serial is not None:
+            psn = int(product_serial)
+        await self.bridge.bind_controller(device_id, pid, psn)
+
+    async def do_bind_accessory(self, ctrl_device_id, device_id, product_id) -> None:
+        """Bind a new accessory."""
+        ctrl_device_id = int(ctrl_device_id)
+        device_id = int(device_id)
+        pid = ProductId(int(product_id))
+        await self.bridge.bind_accessory(ctrl_device_id, device_id, pid)
+
+    async def do_software_build_date(self) -> None:
+        """Print the software build date."""
+        date = await self.bridge.device_software_build_date()
+        print(date)
+
+    async def do_utc_time(self) -> None:
+        """Print the UTC time."""
+        time = await self.bridge.utc_time()
+        print(time)
+
+    async def do_node_oem_number(self) -> None:
+        """Print the node OEM number."""
+        number = await self.bridge.device_oem_number()
+        print(number)
+
+    async def do_oem_code(self) -> None:
+        """Print the OEM code."""
+        number = await self.bridge.oem_code()
+        print(number)
+
+    async def do_set_oem_code(self, number: int) -> None:
+        """Set the OEM code."""
+        await self.bridge.set_oem_code(int(number))
+
+    async def do_status(self) -> None:
+        """Print the device status."""
+        res = await self.bridge.fetch(with_status=False)
+
+        _print_device_data(res)
+
+        print("BRDG-02EM23 data")
+        print("----------------")
+        print(f"    {'Customer product ID:': <40}0x{res[bp.CUSTOMER_PRODUCT_ID].value:08X}")
+        print(f"    {'RF sent messages last hour': <40}{res[bp.MESSAGES_SEND_LAST_HOUR]}")
+        print(f"    {'RF sent messages current hour:': <40}{res[bp.MESSAGES_SEND_CURRENT_HOUR]}")
+        print(f"    {'RF load last hour:': <40}{res[bp.RF_LOAD_LAST_HOUR]}")
+        print(f"    {'RF load current hour:': <40}{res[bp.RF_LOAD_CURRENT_HOUR]}")
+        print(f"    {'Uptime:': <40}{res[bp.UPTIME]}")
+
+    async def do_properties(self, status: bool) -> None:
+        """Print all device properties."""
+        _status = status in (1, "y", "yes")
+        res = await self.bridge.fetch(with_status=_status)
+        pprint.pprint(res)
+
+
 class AiriosClientCLI(aiocmd.PromptToolkitCmd):  # pylint: disable=too-few-public-methods
     """CLI client interface."""
 
@@ -734,8 +1117,15 @@ class AiriosClientCLI(aiocmd.PromptToolkitCmd):  # pylint: disable=too-few-publi
             )
         else:
             _address = int(address)
-        dev = await factory.get_device_by_product_id(ProductId.BRDG_02R13, _address, self.client)
-        await AiriosBridgeCLI(dev).run()
+
+        if isinstance(self.client, AsyncAiriosModbusRtuClient):
+            dev = await factory.get_device_by_product_id(ProductId.BRDG_02R13, _address, self.client)
+            await AiriosSerialBridgeCLI(dev).run()
+        elif isinstance(self.client, AsyncAiriosModbusTcpClient):
+            dev = await factory.get_device_by_product_id(ProductId.BRDG_02EM23, _address, self.client)
+            await AiriosTcpBridgeCLI(dev).run()
+        else:
+            print(f"Unrecognised client type requested")
 
 
 class AiriosRootCLI(aiocmd.PromptToolkitCmd):

--- a/cli.py
+++ b/cli.py
@@ -46,9 +46,11 @@ from pyairios.exceptions import (
     AiriosIOException,
     AiriosNotImplemented,
 )
+from pyairios.models.brdg_02em23 import BRDG02EM23
 from pyairios.models.brdg_02r13 import BRDG02R13
 from pyairios.models.brdg_02r13 import DEFAULT_DEVICE_ID as BRDG02R13_DEFAULT_DEVICE_ID
 from pyairios.models.factory import factory
+from pyairios.models.vmd_15rms86 import VMD15RMS86
 from pyairios.models.vmd_02rps78 import VMD02RPS78
 from pyairios.models.vmd_07rps13 import VMD07RPS13
 from pyairios.models.vmn_05lm02 import VMN05LM02

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = { file="LICENSE" }
 keywords = ["Airios", "Siber", "RAMSES II", "ventilation", "heat-recovery", "modbus", "modbus-tcp", "modbus-rtu"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: Apache Software License",
     "Topic :: Home Automation",
     "Topic :: Scientific/Engineering :: Interface Engine/Protocol Translator",

--- a/src/pyairios/__init__.py
+++ b/src/pyairios/__init__.py
@@ -16,6 +16,7 @@ from pyairios.device import AiriosDevice, AiriosBoundDeviceInfo
 from pyairios.exceptions import AiriosException
 from pyairios.models.brdg_02r13 import BRDG02R13
 from pyairios.models.brdg_02r13 import DEFAULT_DEVICE_ID as BRDG02R13_DEFAULT_DEVICE_ID
+from pyairios.models.brdg_02em23 import BRDG02EM23
 from pyairios.models.factory import factory
 from pyairios.properties import AiriosBridgeProperty as bp
 from pyairios.registers import Result
@@ -27,7 +28,7 @@ class Airios:
     """The Airios RF bridge API."""
 
     _client: AsyncAiriosModbusClient
-    bridge: BRDG02R13
+    bridge: BRDG02R13 | BRDG02EM23
 
     def __init__(
         self, transport: AiriosBaseTransport, device_id: int = BRDG02R13_DEFAULT_DEVICE_ID
@@ -36,12 +37,13 @@ class Airios:
         if isinstance(transport, AiriosTcpTransport):
             transport.__class__ = AiriosTcpTransport
             self._client = AsyncAiriosModbusTcpClient(transport)
+            self.bridge = BRDG02EM23(device_id, self._client)
         elif isinstance(transport, AiriosRtuTransport):
             transport.__class__ = AiriosRtuTransport
             self._client = AsyncAiriosModbusRtuClient(transport)
+            self.bridge = BRDG02R13(device_id, self._client)
         else:
             raise AiriosException(f"Unknown transport {transport}")
-        self.bridge = BRDG02R13(device_id, self._client)
 
     async def nodes(self) -> list[AiriosBoundDeviceInfo]:
         """Get the list of bound nodes."""

--- a/src/pyairios/client.py
+++ b/src/pyairios/client.py
@@ -1,4 +1,4 @@
-"""Async client for the Airios BRDB-02R13 Modbus gateway."""
+"""Async client for the Airios RF Modbus gateway."""
 
 from __future__ import annotations
 

--- a/src/pyairios/constants.py
+++ b/src/pyairios/constants.py
@@ -25,7 +25,7 @@ class ProductId(IntEnum):
     VMN_05LM02 = 0x0001C83E
     VMN_02LM11 = 0x0001C852
     VMD_07RPS13 = 0x0001C883
-    VMD_15RPS86 = 0x0001C8A2
+    VMD_15RMS86 = 0x0001C8A2
 
     def __str__(self) -> str:
         if self.value == self.BRDG_02EM23:
@@ -40,8 +40,8 @@ class ProductId(IntEnum):
             return f"0x{self.value:08X} (VMN-02LM11)"
         if self.value == self.VMD_07RPS13:
             return f"0x{self.value:08X} (VMD-07RPS13)"
-        if self.value == self.VMD_15RPS86:
-            return f"0x{self.value:08X} (VMD-15RPS86)"
+        if self.value == self.VMD_15RMS86:
+            return f"0x{self.value:08X} (VMD-15RMS86)"
         raise ValueError(f"Unknown product ID value {self.value:08X}")
 
 

--- a/src/pyairios/constants.py
+++ b/src/pyairios/constants.py
@@ -20,7 +20,7 @@ class ProductId(IntEnum):
     """
 
     BRDG_02R13 = 0x0001C849
-    BRDG_02EM23 = 0x0001C800  # TODO fill in a verified ID
+    BRDG_02EM23 = 0x0001C848
     VMD_02RPS78 = 0x0001C892
     VMN_05LM02 = 0x0001C83E
     VMN_02LM11 = 0x0001C852

--- a/src/pyairios/constants.py
+++ b/src/pyairios/constants.py
@@ -40,6 +40,8 @@ class ProductId(IntEnum):
             return f"0x{self.value:08X} (VMN-02LM11)"
         if self.value == self.VMD_07RPS13:
             return f"0x{self.value:08X} (VMD-07RPS13)"
+        if self.value == self.VMD_15RPS86:
+            return f"0x{self.value:08X} (VMD-15RPS86)"
         raise ValueError(f"Unknown product ID value {self.value:08X}")
 
 

--- a/src/pyairios/constants.py
+++ b/src/pyairios/constants.py
@@ -20,11 +20,12 @@ class ProductId(IntEnum):
     """
 
     BRDG_02R13 = 0x0001C849
-    BRDG_02EM23 = 0x0001C800  # TODO fill in verified ID
+    BRDG_02EM23 = 0x0001C800  # TODO fill in a verified ID
     VMD_02RPS78 = 0x0001C892
     VMN_05LM02 = 0x0001C83E
     VMN_02LM11 = 0x0001C852
     VMD_07RPS13 = 0x0001C883
+    VMD_15RPS86 = 0x0001C8A2
 
     def __str__(self) -> str:
         if self.value == self.BRDG_02EM23:

--- a/src/pyairios/constants.py
+++ b/src/pyairios/constants.py
@@ -16,16 +16,19 @@ class AiriosDeviceType(Enum):
 class ProductId(IntEnum):
     """The product ID is a unique product identifier.
 
-    The value is composed by three fields, product type + sub ID + manufacturer ID.
+    The value is composed by three fields: product type + sub ID + manufacturer ID.
     """
 
     BRDG_02R13 = 0x0001C849
+    BRDG_02EM23 = 0x0001C800  # TODO fill in verified ID
     VMD_02RPS78 = 0x0001C892
     VMN_05LM02 = 0x0001C83E
     VMN_02LM11 = 0x0001C852
     VMD_07RPS13 = 0x0001C883
 
     def __str__(self) -> str:
+        if self.value == self.BRDG_02EM23:
+            return f"0x{self.value:08X} (BRDG-02EM23)"
         if self.value == self.BRDG_02R13:
             return f"0x{self.value:08X} (BRDG-02R13)"
         if self.value == self.VMD_02RPS78:

--- a/src/pyairios/models/brdg_02em23.py
+++ b/src/pyairios/models/brdg_02em23.py
@@ -13,17 +13,13 @@ from typing import List
 from pyairios.client import AsyncAiriosModbusClient
 from pyairios.constants import (
     AiriosDeviceType,
-    Baudrate,
     BindingMode,
     BindingStatus,
     ModbusEvents,
-    Parity,
     ProductId,
     ResetMode,
     RFLoad,
     RFSentMessages,
-    SerialConfig,
-    StopBits,
 )
 from pyairios.device import AiriosDevice, AiriosBoundDeviceInfo
 from pyairios.exceptions import (
@@ -44,7 +40,7 @@ from pyairios.registers import (
     U32Register,
 )
 
-DEFAULT_DEVICE_ID = 207
+DEFAULT_DEVICE_ID = 1
 
 LOGGER = logging.getLogger(__name__)
 
@@ -113,10 +109,6 @@ class BRDG02EM23(AiriosDevice):
             U16Register(bp.MODBUS_EVENTS, 41103, RegisterAccess.READ | RegisterAccess.WRITE),
             U16Register(bp.RESET_DEVICE, 41107, RegisterAccess.WRITE),
             StringRegister(bp.CUSTOMER_SPECIFIC_NODE_ID, 41108, 10, RegisterAccess.WRITE),
-            U16Register(bp.SERIAL_PARITY, 41998, RegisterAccess.READ | RegisterAccess.WRITE),
-            U16Register(bp.SERIAL_STOP_BITS, 41999, RegisterAccess.READ | RegisterAccess.WRITE),
-            U16Register(bp.SERIAL_BAUDRATE, 42000, RegisterAccess.READ | RegisterAccess.WRITE),
-            U16Register(bp.MODBUS_DEVICE_ID, 42001, RegisterAccess.READ | RegisterAccess.WRITE),
             U16Register(bp.MESSAGES_SEND_CURRENT_HOUR, 42100, RegisterAccess.READ),
             U16Register(bp.MESSAGES_SEND_LAST_HOUR, 42101, RegisterAccess.READ),
             FloatRegister(bp.RF_LOAD_CURRENT_HOUR, 42102, RegisterAccess.READ),
@@ -423,35 +415,6 @@ class BRDG02EM23(AiriosDevice):
         r2 = await self.rf_sent_messages_last_hour()
         return RFSentMessages(messages_current_hour=r1.value, messages_last_hour=r2.value)
 
-    async def serial_config(self) -> SerialConfig:
-        """Get the serial configuration."""
-        result = await self.client.get_register(self.regmap[bp.SERIAL_BAUDRATE], self.device_id)
-        baudrate: Baudrate = Baudrate(result.value)
-        result = await self.client.get_register(self.regmap[bp.SERIAL_PARITY], self.device_id)
-        parity: Parity = Parity(result.value)
-        result = await self.client.get_register(self.regmap[bp.SERIAL_STOP_BITS], self.device_id)
-        stopbits: StopBits = StopBits(result.value)
-        return SerialConfig(baudrate=baudrate, stop_bits=stopbits, parity=parity)
-
-    async def set_serial_config(self, config: SerialConfig) -> bool:
-        """Set the serial configuration."""
-        return (
-            await self.client.set_register(
-                self.regmap[bp.SERIAL_BAUDRATE],
-                config.baudrate,
-                self.device_id,
-            )
-            and await self.client.set_register(
-                self.regmap[bp.SERIAL_PARITY],
-                config.parity,
-                self.device_id,
-            )
-            and await self.client.set_register(
-                self.regmap[bp.SERIAL_STOP_BITS],
-                config.stop_bits,
-                self.device_id,
-            )
-        )
 
     async def modbus_events(self) -> Result[ModbusEvents]:
         """Modbus event responses via special Modbus functions."""

--- a/src/pyairios/models/brdg_02em23.py
+++ b/src/pyairios/models/brdg_02em23.py
@@ -1,4 +1,7 @@
-"""Airios BRDG-02R13 RS485 RF bridge implementation."""
+"""Airios BRDG-02EM23 UTP RF bridge implementation."""
+# TODO:
+# - change below to pymodbus tcp client methods
+# see https://pymodbus.readthedocs.io/en/latest/source/client.html
 
 from __future__ import annotations
 
@@ -48,7 +51,7 @@ LOGGER = logging.getLogger(__name__)
 
 def pr_id() -> ProductId:
     """
-    Get product_id for model BRDG-02R13.
+    Get product_id for model BRDG-02EM23.
     Named as is to discern from product_id register.
     :return: unique int
     """
@@ -64,15 +67,15 @@ def pr_type() -> AiriosDeviceType:
 
 def pr_description() -> list[str]:
     """
-    Get description of product(s) using BRDG-02R13.
+    Get description of product(s) using BRDG-02EM23.
     Human-readable text, used in e.g. HomeAssistant Binding UI.
     """
-    return ["Airios RS485 RF Gateway"]
+    return ["Airios TCP RF Gateway"]
 
 
-def pr_instantiate(device_id: int, client: AsyncAiriosModbusClient) -> BRDG02R13:
+def pr_instantiate(device_id: int, client: AsyncAiriosModbusClient) -> BRDG02EM23:
     """Get a new device instance. Used by the device factory to instantiate by product ID."""
-    return BRDG02R13(device_id, client)
+    return BRDG02EM23(device_id, client)
 
 
 def datetime_register(value: int) -> datetime.datetime:
@@ -82,11 +85,11 @@ def datetime_register(value: int) -> datetime.datetime:
     return datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc)
 
 
-class BRDG02R13(AiriosDevice):
-    """Represents a BRDG-02R13 RF bridge."""
+class BRDG02EM23(AiriosDevice):
+    """Represents a BRDG-02EM23 TCP RF bridge."""
 
     def __init__(self, device_id: int, client: AsyncAiriosModbusClient) -> None:
-        """Initialize the BRDG-02R13 RF bridge instance."""
+        """Initialize the BRDG-02EM23 RF bridge instance."""
 
         super().__init__(device_id, client)
         brdg_registers: List[RegisterBase] = [
@@ -174,7 +177,7 @@ class BRDG02R13(AiriosDevice):
         self._add_registers(brdg_registers)
 
     def __str__(self) -> str:
-        return f"BRDG-02R13@{self.device_id}"
+        return f"BRDG-02EM23@{self.device_id}"
 
     def pr_id(self) -> ProductId:
         return pr_id()

--- a/src/pyairios/models/brdg_02em23.py
+++ b/src/pyairios/models/brdg_02em23.py
@@ -55,7 +55,7 @@ def pr_id() -> ProductId:
     Named as is to discern from product_id register.
     :return: unique int
     """
-    return ProductId.BRDG_02R13
+    return ProductId.BRDG_02EM23
 
 
 def pr_type() -> AiriosDeviceType:

--- a/src/pyairios/models/vmd_15rms86.py
+++ b/src/pyairios/models/vmd_15rms86.py
@@ -1,4 +1,4 @@
-"""Airios VMD-99RPS99 controller implementation (Orcon)."""
+"""Airios VMD-15RPS86 controller implementation (generic Orcon)."""
 
 from __future__ import annotations
 
@@ -10,19 +10,22 @@ from pyairios.client import AsyncAiriosModbusClient
 from pyairios.constants import (
     AiriosDeviceType,
     ProductId,
+    VMDBypassMode,
     VMDBypassPosition,
+    VMDCapabilities,
     VMDCO2Level,
     VMDErrorCode,
     VMDFlowLevel,
     VMDHeater,
-    VMDHeaterStatus,
+    # VMDHeaterStatus,
     VMDHumidity,
+    VMDPresetFansSpeeds,
     VMDRequestedVentilationSpeed,
     VMDSensorStatus,
     VMDTemperature,
-    VMDVentilationMode,
     VMDVentilationSpeed,
 )
+from pyairios.exceptions import AiriosInvalidArgumentException
 from pyairios.node import AiriosNode
 from pyairios.properties import AiriosVMDProperty as vp
 from pyairios.registers import (
@@ -30,7 +33,6 @@ from pyairios.registers import (
     RegisterAccess,
     RegisterBase,
     Result,
-    U8Register,
     U16Register,
 )
 
@@ -39,10 +41,10 @@ LOGGER = logging.getLogger(__name__)
 
 def pr_id() -> ProductId:
     """
-    Get product_id for model VMD_07RPS13.
+    Get product_id for model VMD_15RPS86.
     Named as is to discern from product_id register.
     """
-    return ProductId.VMD_07RPS13
+    return ProductId.VMD_15RPS86
 
 
 def pr_type() -> AiriosDeviceType:
@@ -54,16 +56,16 @@ def pr_type() -> AiriosDeviceType:
 
 def pr_description() -> list[str]:
     """
-    Get description of product(s) using VMD_07RPS13.
+    Get description of product(s) using VMD_15RPS86.
     Human-readable text, used in e.g. HomeAssistant Binding UI.
     :return: string or tuple of strings, starting with manufacturer
     """
-    return ["ClimaRad Ventura V1"]
+    return ["Orcon Generic"]
 
 
-def pr_instantiate(device_id: int, client: AsyncAiriosModbusClient) -> VMD07RPS13:
+def pr_instantiate(device_id: int, client: AsyncAiriosModbusClient) -> VMD15RMS86:
     """Get a new device instance. Used by the device factory to instantiate by product ID."""
-    return VMD07RPS13(device_id, client)
+    return VMD15RMS86(device_id, client)
 
 
 def _temperature_adapter(value: float) -> VMDTemperature:
@@ -123,35 +125,33 @@ def _bypass_position_adapter(value) -> VMDBypassPosition:
     return VMDBypassPosition(value, error)
 
 
-def _heater_adapter(value) -> VMDHeater:
-    status = VMDHeaterStatus.UNAVAILABLE if value == 0xEF else VMDHeaterStatus.OK
-    return VMDHeater(value, status)
+# def _heater_adapter(value) -> VMDHeater:
+#     status = VMDHeaterStatus.UNAVAILABLE if value == 0xEF else VMDHeaterStatus.OK
+#     return VMDHeater(value, status)
 
 
 class VMD15RMS86(AiriosNode):
-    """Represents a VMD-15RMS86 controller node."""
+    """Airios VMD-15RMS86 controller implementation."""
 
     def __init__(self, device_id: int, client: AsyncAiriosModbusClient) -> None:
-        """Initialize the VMD-15RMS86 Orcon controller node instance."""
+        """Initialize the VMD-02RPS78 controller node instance."""
         super().__init__(device_id, client)
         vmd_registers: List[RegisterBase] = [
-            FloatRegister(
-                vp.TEMPERATURE_OUTLET,
-                41000,
-                RegisterAccess.READ | RegisterAccess.STATUS,
-                result_adapter=_temperature_adapter,
+            U16Register(
+                vp.CURRENT_VENTILATION_SPEED, 41000, RegisterAccess.READ | RegisterAccess.STATUS
             ),
-            U8Register(
-                vp.HUMIDITY_OUTDOOR,
-                41002,
-                RegisterAccess.READ | RegisterAccess.STATUS,
-                result_adapter=_humidity_adapter,
-            ),
-            FloatRegister(
-                vp.TEMPERATURE_INLET,
+            U16Register(vp.FAN_SPEED_EXHAUST, 41001, RegisterAccess.READ | RegisterAccess.STATUS),
+            U16Register(vp.FAN_SPEED_SUPPLY, 41002, RegisterAccess.READ | RegisterAccess.STATUS),
+            U16Register(
+                vp.ERROR_CODE,
                 41003,
                 RegisterAccess.READ | RegisterAccess.STATUS,
-                result_adapter=_temperature_adapter,
+                result_type=VMDErrorCode,
+            ),
+            U16Register(
+                vp.VENTILATION_SPEED_OVERRIDE_REMAINING_TIME,
+                41004,
+                RegisterAccess.READ | RegisterAccess.STATUS,
             ),
             FloatRegister(
                 vp.TEMPERATURE_EXHAUST,
@@ -159,116 +159,199 @@ class VMD15RMS86(AiriosNode):
                 RegisterAccess.READ | RegisterAccess.STATUS,
                 result_adapter=_temperature_adapter,
             ),
-            U8Register(
-                vp.HUMIDITY_INDOOR,
+            FloatRegister(
+                vp.TEMPERATURE_INLET,
                 41007,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_temperature_adapter,
+            ),
+            FloatRegister(
+                vp.TEMPERATURE_OUTLET,
+                41009,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_temperature_adapter,
+            ),
+            FloatRegister(
+                vp.TEMPERATURE_SUPPLY,
+                41011,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_temperature_adapter,
+            ),
+            # U16Register(
+            #     vp.PREHEATER,
+            #     41013,
+            #     RegisterAccess.READ | RegisterAccess.STATUS,
+            #     result_adapter=_heater_adapter,
+            # ),
+            U16Register(vp.FILTER_DIRTY, 41014, RegisterAccess.READ | RegisterAccess.STATUS),
+            U16Register(vp.DEFROST, 41015, RegisterAccess.READ | RegisterAccess.STATUS),
+            U16Register(
+                vp.BYPASS_POSITION,
+                41016,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_bypass_position_adapter,
+            ),
+            U16Register(
+                vp.HUMIDITY_INDOOR,
+                41017,
                 RegisterAccess.READ | RegisterAccess.STATUS,
                 result_adapter=_humidity_adapter,
             ),
             U16Register(
-                vp.CO2_LEVEL,
-                41008,
+                vp.HUMIDITY_OUTDOOR,
+                41018,
                 RegisterAccess.READ | RegisterAccess.STATUS,
-                result_adapter=_co2_adapter,
+                result_adapter=_humidity_adapter,
             ),
-            U8Register(
-                vp.BYPASS_POSITION,
-                41015,
-                RegisterAccess.READ | RegisterAccess.STATUS,
-                result_adapter=_bypass_position_adapter,
-            ),
-            U8Register(vp.FILTER_DIRTY, 41017, RegisterAccess.READ | RegisterAccess.STATUS),
-            U8Register(vp.FAN_SPEED_EXHAUST, 41019, RegisterAccess.READ | RegisterAccess.STATUS),
-            U8Register(vp.FAN_SPEED_SUPPLY, 41020, RegisterAccess.READ | RegisterAccess.STATUS),
-            U8Register(
-                vp.POSTHEATER,
-                41023,
-                RegisterAccess.READ | RegisterAccess.STATUS,
-                result_adapter=_heater_adapter,
-            ),
-            FloatRegister(
-                vp.FLOW_INLET,
-                41024,
-                RegisterAccess.READ | RegisterAccess.STATUS,
-                result_adapter=_flow_adapter,
-            ),
+            # FloatRegister(
+            #     vp.FLOW_INLET,
+            #     41019,
+            #     RegisterAccess.READ | RegisterAccess.STATUS,
+            #     result_adapter=_flow_adapter,
+            # ),
             FloatRegister(
                 vp.FLOW_OUTLET,
-                41026,
+                41021,
                 RegisterAccess.READ | RegisterAccess.STATUS,
                 result_adapter=_flow_adapter,
             ),
+            # U16Register(vp.AIR_QUALITY, 41023, RegisterAccess.READ | RegisterAccess.STATUS),
+            # U16Register(vp.AIR_QUALITY_BASIS, 41024, RegisterAccess.READ | RegisterAccess.STATUS),
+            # U16Register(
+            #     vp.CO2_LEVEL,
+            #     41025,
+            #     RegisterAccess.READ | RegisterAccess.STATUS,
+            #     result_adapter=_co2_adapter,
+            # ),
+            # U16Register(
+            #     vp.POSTHEATER,
+            #     41026,
+            #     RegisterAccess.READ | RegisterAccess.STATUS,
+            #     result_adapter=_heater_adapter,
+            # ),
             U16Register(
-                vp.FILTER_REMAINING_DAYS, 41028, RegisterAccess.READ | RegisterAccess.STATUS
-            ),
-            U16Register(vp.FILTER_DURATION, 41029, RegisterAccess.READ | RegisterAccess.STATUS),
-            U8Register(
-                vp.FILTER_REMAINING_PERCENT, 41030, RegisterAccess.READ | RegisterAccess.STATUS
-            ),
-            U8Register(vp.ERROR_CODE, 41032, RegisterAccess.READ | RegisterAccess.STATUS),
-            U8Register(
-                vp.VENTILATION_MODE,
-                41100,
+                vp.CAPABILITIES,
+                41027,
                 RegisterAccess.READ | RegisterAccess.STATUS,
-                result_type=VMDVentilationMode,
+                result_type=VMDCapabilities,
             ),
-            U8Register(vp.VENTILATION_SUB_MODE, 41101, RegisterAccess.READ | RegisterAccess.STATUS),
-            U8Register(
-                vp.TEMP_VENTILATION_MODE, 41103, RegisterAccess.READ | RegisterAccess.STATUS
+            U16Register(
+                vp.FILTER_REMAINING_DAYS, 41040, RegisterAccess.READ | RegisterAccess.STATUS
             ),
-            U8Register(
-                vp.TEMP_VENTILATION_SUB_MODE, 41104, RegisterAccess.READ | RegisterAccess.STATUS
+            # U16Register(vp.FILTER_DURATION, 41041, RegisterAccess.READ | RegisterAccess.STATUS),
+            U16Register(
+                vp.FILTER_REMAINING_PERCENT, 41042, RegisterAccess.READ | RegisterAccess.STATUS
             ),
-            U8Register(
-                vp.REQUESTED_VENTILATION_MODE,
-                41120,
+            U16Register(vp.FAN_RPM_EXHAUST, 41043, RegisterAccess.READ | RegisterAccess.STATUS),
+            U16Register(vp.FAN_RPM_SUPPLY, 41044, RegisterAccess.READ | RegisterAccess.STATUS),
+            # U16Register(vp.BYPASS_MODE, 41050, RegisterAccess.READ | RegisterAccess.STATUS),
+            U16Register(vp.BYPASS_STATUS, 41051, RegisterAccess.READ | RegisterAccess.STATUS),
+            U16Register(
+                vp.REQUESTED_VENTILATION_SPEED,
+                41500,  # to be confirmed by remy
                 RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
             ),
-            U8Register(
-                vp.REQUESTED_VENTILATION_SUB_MODE,
-                41121,
+            # U16Register(
+            #     vp.OVERRIDE_TIME_SPEED_LOW,
+            #     41501,
+            #     RegisterAccess.WRITE,
+            #     max_value=18 * 60,
+            # ),
+            # U16Register(
+            #     vp.OVERRIDE_TIME_SPEED_MID,
+            #     41502,
+            #     RegisterAccess.WRITE,
+            #     max_value=18 * 60,
+            # ),
+            # U16Register(
+            #     vp.OVERRIDE_TIME_SPEED_HIGH,
+            #     41503,
+            #     RegisterAccess.WRITE,
+            #     max_value=18 * 60,
+            # ),
+            U16Register(
+                vp.REQUESTED_BYPASS_MODE,
+                41550,
                 RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
             ),
-            U8Register(
-                vp.REQUESTED_TEMP_VENTILATION_MODE,
-                41123,
-                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
-            ),
-            U8Register(
-                vp.REQUESTED_TEMP_VENTILATION_SUB_MODE,
-                41124,
-                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
-            ),
-            U8Register(vp.FILTER_RESET, 41151, RegisterAccess.WRITE | RegisterAccess.STATUS),
-            U8Register(
-                vp.BASIC_VENTILATION_ENABLE,
-                42000,
-                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
-            ),
-            U8Register(
-                vp.BASIC_VENTILATION_LEVEL,
+            U16Register(vp.FILTER_RESET, 42000, RegisterAccess.WRITE | RegisterAccess.STATUS),
+            U16Register(
+                vp.FAN_SPEED_AWAY_SUPPLY,
                 42001,
                 RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+                max_value=40,
             ),
             U16Register(
-                vp.TEMP_OVERRIDE_DURATION, 42009, (RegisterAccess.READ | RegisterAccess.WRITE)
-            ),
-            U16Register(vp.CO2_CONTROL_SETPOINT, 42011, RegisterAccess.READ | RegisterAccess.WRITE),
-            U8Register(
-                vp.PRODUCT_VARIANT,
-                41010,
+                vp.FAN_SPEED_AWAY_EXHAUST,
+                42002,
                 RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+                max_value=40,
             ),
-            U8Register(
-                vp.SYSTEM_VENTILATION_CONFIGURATION,
-                42021,
+            U16Register(
+                vp.FAN_SPEED_LOW_SUPPLY,
+                42003,
                 RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+                max_value=80,
             ),
+            U16Register(
+                vp.FAN_SPEED_LOW_EXHAUST,
+                42004,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+                max_value=80,
+            ),
+            U16Register(
+                vp.FAN_SPEED_MID_SUPPLY,
+                42005,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+                max_value=100,
+            ),
+            U16Register(
+                vp.FAN_SPEED_MID_EXHAUST,
+                42006,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+                max_value=100,
+            ),
+            U16Register(
+                vp.FAN_SPEED_HIGH_SUPPLY,
+                42007,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+                max_value=100,
+            ),
+            U16Register(
+                vp.FAN_SPEED_HIGH_EXHAUST,
+                42008,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+                max_value=100,
+            ),
+            U16Register(vp.CO2_CONTROL_SETPOINT, 49017, RegisterAccess.READ | RegisterAccess.WRITE),
+            U16Register(
+                vp.TEMPERATURE_CONTROL_SETPOINT, 49017, RegisterAccess.READ | RegisterAccess.WRITE
+            ),
+            # FloatRegister(
+            #     vp.FROST_PROTECTION_PREHEATER_SETPOINT,
+            #     42009,
+            #     RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            # ),
+            # FloatRegister(
+            #     vp.PREHEATER_SETPOINT,
+            #     42011,
+            #     RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            # ),
+            # FloatRegister(
+            #     vp.FREE_VENTILATION_HEATING_SETPOINT,
+            #     42013,
+            #     RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            # ),
+            # FloatRegister(
+            #     vp.FREE_VENTILATION_COOLING_OFFSET,
+            #     42015,
+            #     RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            # ),
         ]
         self._add_registers(vmd_registers)
 
     def __str__(self) -> str:
-        return f"VMD-07RPS13@{self.device_id}"
+        return f"VMD-02RPS78@{self.device_id}"
 
     def pr_id(self) -> ProductId:
         return pr_id()
@@ -279,148 +362,127 @@ class VMD15RMS86(AiriosNode):
     def pr_description(self) -> list[str]:
         return pr_description()
 
+    async def capabilities(self) -> Result[VMDCapabilities]:
+        """Get the ventilation unit capabilities."""
+        regdesc = self.regmap[vp.CAPABILITIES]
+        result = await self.client.get_register(regdesc, self.device_id)
+        return Result(VMDCapabilities(result.value), result.status)
+
     async def ventilation_speed(self) -> Result[VMDVentilationSpeed]:
         """Get the ventilation unit active speed preset."""
-
-        # Automatic:
-        # Ventilation mode:        2
-        # Ventilation sub mode:    48
-        # Temp. Ventil. mode:      0
-        # Temp. Ventil. sub mode:  0
-        #
-        # Pause:
-        # Ventilation mode:        1
-        # Ventilation sub mode:    0
-        # Temp. Ventil. mode:      1
-        # Temp. Ventil. sub mode:  0
-        #
-        # Manual/temp 1:
-        # Ventilation mode:        0
-        # Ventilation sub mode:    0
-        # Temp. Ventil. mode:      3
-        # Temp. Ventil. sub mode:  201
-        #
-        # Manual/temp 2:
-        # Ventilation mode:        0
-        # Ventilation sub mode:    0
-        # Temp. Ventil. mode:      3
-        # Temp. Ventil. sub mode:  202
-        #
-        # Ventilation mode:        0
-        # Ventilation sub mode:    0
-        # Temp. Ventil. mode:      3
-        # Temp. Ventil. sub mode:  203
-        #
-        # Stand 5 == Boost >>
-        # Ventilation mode:        0
-        # Ventilation sub mode:    0
-        # Temp. Ventil. mode:      3
-        # Temp. Ventil. sub mode:  205
-
-        mode = await self.client.get_register(self.regmap[vp.VENTILATION_MODE], self.device_id)
-        man_step = await self.client.get_register(
-            self.regmap[vp.TEMP_VENTILATION_SUB_MODE], self.device_id
-        )
-        speed = VMDVentilationSpeed.OFF
-        if mode.value == 2:
-            speed = VMDVentilationSpeed.AUTO
-        elif mode.value == 1:
-            speed = VMDVentilationSpeed.AWAY
-        elif mode.value == 0:
-            if man_step.value <= 202:
-                speed = VMDVentilationSpeed.OVERRIDE_LOW
-            elif man_step.value <= 203:
-                speed = VMDVentilationSpeed.OVERRIDE_MID
-            elif man_step.value <= 205:
-                speed = VMDVentilationSpeed.OVERRIDE_HIGH
-        return Result(speed, mode.status)
+        regdesc = self.regmap[vp.CURRENT_VENTILATION_SPEED]
+        result = await self.client.get_register(regdesc, self.device_id)
+        return Result(VMDVentilationSpeed(result.value), result.status)
 
     async def set_ventilation_speed(self, speed: VMDRequestedVentilationSpeed) -> bool:
-        """Set the ventilation unit speed (temp 8H) preset."""
-        md = 0  # VMDVentilationSpeed.OFF, PAUSE?
-        if speed == VMDRequestedVentilationSpeed.AUTO:
-            md = 0
-        elif speed == VMDRequestedVentilationSpeed.AWAY:
-            md = 0
-        elif speed == VMDRequestedVentilationSpeed.LOW:
-            md = 202
-        elif speed == VMDRequestedVentilationSpeed.MID:
-            md = 203
-        elif speed == VMDRequestedVentilationSpeed.HIGH:
-            md = 205
+        """Set the ventilation unit speed preset."""
+        return await self.client.set_register(
+            self.regmap[vp.REQUESTED_VENTILATION_SPEED], speed, self.device_id
+        )
 
-        regdesc = self.regmap[vp.REQUESTED_VENTILATION_SUB_MODE]
-        # check why no immediate change
-        return await self.client.set_register(regdesc, md, self.device_id)
+    async def set_ventilation_speed_override_time(
+        self, speed: VMDRequestedVentilationSpeed, minutes: int
+    ) -> bool:
+        """Set the ventilation unit speed preset for a limited time."""
+        if speed == VMDRequestedVentilationSpeed.LOW:
+            return await self.client.set_register(
+                self.regmap[vp.OVERRIDE_TIME_SPEED_LOW], minutes, self.device_id
+            )
+        if speed == VMDRequestedVentilationSpeed.MID:
+            return await self.client.set_register(
+                self.regmap[vp.OVERRIDE_TIME_SPEED_MID], minutes, self.device_id
+            )
+        if speed == VMDRequestedVentilationSpeed.HIGH:
+            return await self.client.set_register(
+                self.regmap[vp.OVERRIDE_TIME_SPEED_HIGH], minutes, self.device_id
+            )
+        raise AiriosInvalidArgumentException(f"Invalid temporary override speed {speed}")
 
-    async def system_ventilation_configuration(self) -> Result[int]:
-        """Get the system ventilation configuration status."""
-        regdesc = self.regmap[vp.SYSTEM_VENTILATION_CONFIGURATION]
-        return await self.client.get_register(regdesc, self.device_id)
+    async def preset_away_fans_speed(self) -> VMDPresetFansSpeeds:
+        """Get the away ventilation speed preset fan speeds."""
+        r1 = await self.client.get_register(self.regmap[vp.FAN_SPEED_AWAY_SUPPLY], self.device_id)
+        r2 = await self.client.get_register(self.regmap[vp.FAN_SPEED_AWAY_EXHAUST], self.device_id)
+        return VMDPresetFansSpeeds(supply_fan_speed=r1.value, exhaust_fan_speed=r2.value)
 
-    async def ventilation_mode(self) -> Result[VMDVentilationMode]:
-        """Get the ventilation mode status. 0=Off, 1=Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
-        # seen: 0 (with temp_vent_mode 3) | 1 = Pause | 2 = On (with vent_sub_mode 48)
-        regdesc = self.regmap[vp.VENTILATION_MODE]
-        return await self.client.get_register(regdesc, self.device_id)
+    async def set_preset_away_fans_speed(self, supply: int, exhaust: int) -> bool:
+        """Set the away ventilation speed preset fan speeds."""
+        r1 = await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_AWAY_SUPPLY], supply, self.device_id
+        )
+        r2 = await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_AWAY_EXHAUST], exhaust, self.device_id
+        )
+        return r1 and r2
 
-    async def set_ventilation_mode(self, mode: VMDVentilationMode) -> bool:
-        """Set the ventilation mode. 0=Off, 2=On, 3=Man1, 5=Man3, 8=Service"""
-        regdesc = self.regmap[vp.REQUESTED_VENTILATION_MODE]
-        return await self.client.set_register(regdesc, mode, self.device_id)
+    async def preset_low_fans_speed(self) -> VMDPresetFansSpeeds:
+        """Get the low ventilation speed preset fan speeds."""
+        r1 = await self.client.get_register(self.regmap[vp.FAN_SPEED_LOW_SUPPLY], self.device_id)
+        r2 = await self.client.get_register(self.regmap[vp.FAN_SPEED_LOW_EXHAUST], self.device_id)
+        return VMDPresetFansSpeeds(supply_fan_speed=r1.value, exhaust_fan_speed=r2.value)
 
-    async def requested_ventilation_mode(self) -> Result[VMDVentilationMode]:
-        """Get the ventilation mode status. 0=Off, 2=On, 3=Man1, 5=Man3, 8=Service"""
-        regdesc = self.regmap[vp.REQUESTED_VENTILATION_MODE]
-        return await self.client.get_register(regdesc, self.device_id)
+    async def set_preset_low_fans_speed(self, supply: int, exhaust: int) -> bool:
+        """Set the low ventilation speed preset fan speeds."""
+        r1 = await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_LOW_SUPPLY], supply, self.device_id
+        )
+        r2 = await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_LOW_EXHAUST], exhaust, self.device_id
+        )
+        return r1 and r2
 
-    async def ventilation_sub_mode(self) -> Result[int]:
-        """Get the ventilation sub mode status."""
-        # seen: 0 | 48
-        regdesc = self.regmap[vp.VENTILATION_SUB_MODE]
-        return await self.client.get_register(regdesc, self.device_id)
+    async def preset_mid_fans_speed(self) -> VMDPresetFansSpeeds:
+        """Get the mid ventilation speed preset fan speeds."""
+        r1 = await self.client.get_register(self.regmap[vp.FAN_SPEED_MID_SUPPLY], self.device_id)
+        r2 = await self.client.get_register(self.regmap[vp.FAN_SPEED_MID_EXHAUST], self.device_id)
+        return VMDPresetFansSpeeds(supply_fan_speed=r1.value, exhaust_fan_speed=r2.value)
 
-    async def set_ventilation_sub_mode(self, mode: int) -> bool:
-        """Set the ventilation sub mode. 0=Off/Pause, 48=Auto"""
-        regdesc = self.regmap[vp.REQUESTED_VENTILATION_SUB_MODE]
-        return await self.client.set_register(regdesc, mode, self.device_id)
+    async def set_preset_mid_fans_speed(self, supply: int, exhaust: int) -> bool:
+        """Set the mid ventilation speed preset fan speeds."""
+        r1 = await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_MID_SUPPLY], supply, self.device_id
+        )
+        r2 = await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_MID_EXHAUST], exhaust, self.device_id
+        )
+        return r1 and r2
 
-    async def requested_ventilation_sub_mode(self) -> Result[int]:
-        """Get the ventilation mode status. 0=Off/Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
-        regdesc = self.regmap[vp.REQUESTED_VENTILATION_SUB_MODE]
-        return await self.client.get_register(regdesc, self.device_id)
+    async def preset_high_fans_speed(self) -> VMDPresetFansSpeeds:
+        """Get the high ventilation speed preset fan speeds."""
+        r1 = await self.client.get_register(self.regmap[vp.FAN_SPEED_HIGH_SUPPLY], self.device_id)
+        r2 = await self.client.get_register(self.regmap[vp.FAN_SPEED_HIGH_EXHAUST], self.device_id)
+        return VMDPresetFansSpeeds(supply_fan_speed=r1.value, exhaust_fan_speed=r2.value)
 
-    async def temp_ventilation_mode(self) -> Result[int]:
-        """Get the temporary ventilation mode status."""
-        # seen: 0 (with Ventilation mode != 0) | 3
-        regdesc = self.regmap[vp.TEMP_VENTILATION_MODE]
-        return await self.client.get_register(regdesc, self.device_id)
+    async def set_preset_high_fans_speed(self, supply: int, exhaust: int) -> bool:
+        """Set the high ventilation speed preset fan speeds."""
+        r1 = await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_HIGH_SUPPLY], supply, self.device_id
+        )
+        r2 = await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_HIGH_EXHAUST], exhaust, self.device_id
+        )
+        return r1 and r2
 
-    async def temp_ventilation_sub_mode(self) -> Result[int]:
-        """Get the temporary ventilation sub mode status."""
-        # seen: 0 (with temp_vent_mode 3) | 201 | 202 | .. | 205
-        regdesc = self.regmap[vp.TEMP_VENTILATION_SUB_MODE]
-        return await self.client.get_register(regdesc, self.device_id)
+    async def bypass_mode(self) -> Result[VMDBypassMode]:
+        """Get the bypass mode."""
+        regdesc = self.regmap[vp.BYPASS_MODE]
+        result = await self.client.get_register(regdesc, self.device_id)
+        try:
+            mode = VMDBypassMode(result.value)
+        except ValueError:
+            mode = VMDBypassMode.UNKNOWN
+        return Result(mode, result.status)
 
-    async def set_temp_ventilation_mode(self, mode: int) -> bool:
-        """Set the temp ventilation mode. 0=Off, 1=Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
-        regdesc = self.regmap[vp.REQUESTED_TEMP_VENTILATION_MODE]
-        return await self.client.set_register(regdesc, mode, self.device_id)
+    async def set_bypass_mode(self, mode: VMDBypassMode) -> bool:
+        """Set the bypass mode."""
+        if mode == VMDBypassMode.UNKNOWN:
+            raise AiriosInvalidArgumentException(f"Invalid bypass mode {mode}")
+        return await self.client.set_register(
+            self.regmap[vp.REQUESTED_BYPASS_MODE], mode, self.device_id
+        )
 
-    async def requested_temp_ventilation_mode(self) -> Result[int]:
-        """Get the temp ventilation mode status. 0=Off, 1=Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
-        regdesc = self.regmap[vp.REQUESTED_TEMP_VENTILATION_MODE]
-        return await self.client.get_register(regdesc, self.device_id)
-
-    async def set_temp_ventilation_sub_mode(self, mode: int) -> bool:
-        """Set the temp ventilation sub mode. 0=Off/Pause, 201, ..."""
-        regdesc = self.regmap[vp.REQUESTED_TEMP_VENTILATION_SUB_MODE]
-        return await self.client.set_register(regdesc, mode, self.device_id)
-
-    async def requested_temp_ventilation_sub_mode(self) -> Result[int]:
-        """Get the temp ventilation sub mode status. 0=Off/Pause, 201, ..."""
-        regdesc = self.regmap[vp.REQUESTED_TEMP_VENTILATION_SUB_MODE]
-        return await self.client.get_register(regdesc, self.device_id)
+    async def bypass_status(self) -> Result[int]:
+        """Get the bypass status."""
+        return await self.client.get_register(self.regmap[vp.BYPASS_STATUS], self.device_id)
 
     async def bypass_position(self) -> Result[VMDBypassPosition]:
         """Get the bypass position."""
@@ -435,7 +497,7 @@ class VMD15RMS86(AiriosNode):
         """Get the filter remaining lifetime (in days)."""
         return await self.client.get_register(self.regmap[vp.FILTER_REMAINING_DAYS], self.device_id)
 
-    async def filter_remaining_percent(self) -> Result[int]:
+    async def filter_remaining(self) -> Result[int]:
         """Get the filter remaining lifetime (in %)."""
         return await self.client.get_register(
             self.regmap[vp.FILTER_REMAINING_PERCENT], self.device_id
@@ -473,6 +535,20 @@ class VMD15RMS86(AiriosNode):
         """Get the supply fan speed (%)"""
         return await self.client.get_register(self.regmap[vp.FAN_SPEED_SUPPLY], self.device_id)
 
+    async def exhaust_fan_rpm(self) -> Result[int]:
+        """Get the exhaust fan speed (RPM)"""
+        return await self.client.get_register(self.regmap[vp.FAN_RPM_EXHAUST], self.device_id)
+
+    async def supply_fan_rpm(self) -> Result[int]:
+        """Get the supply fan speed (RPM)"""
+        return await self.client.get_register(self.regmap[vp.FAN_RPM_SUPPLY], self.device_id)
+
+    async def override_remaining_time(self) -> Result[int]:
+        """Get the ventilation speed override remaining time."""
+        return await self.client.get_register(
+            self.regmap[vp.VENTILATION_SPEED_OVERRIDE_REMAINING_TIME], self.device_id
+        )
+
     async def indoor_air_temperature(self) -> Result[VMDTemperature]:
         """Get the indoor air temperature.
 
@@ -497,39 +573,157 @@ class VMD15RMS86(AiriosNode):
         regdesc = self.regmap[vp.TEMPERATURE_OUTLET]
         return await self.client.get_register(regdesc, self.device_id)
 
+    async def supply_air_temperature(self) -> Result[VMDTemperature]:
+        """Get the supply air temperature.
+
+        This is the supply flow after the heat exchanger.
+        """
+        regdesc = self.regmap[vp.TEMPERATURE_SUPPLY]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def defrost(self) -> Result[int]:
+        """Get if defrost is active."""
+        return await self.client.get_register(self.regmap[vp.DEFROST], self.device_id)
+
+    async def preheater(self) -> Result[VMDHeater]:
+        """Get the preheater level."""
+        regdesc = self.regmap[vp.PREHEATER]
+        return await self.client.get_register(regdesc, self.device_id)
+
     async def postheater(self) -> Result[VMDHeater]:
         """Get the postheater level."""
         regdesc = self.regmap[vp.POSTHEATER]
         return await self.client.get_register(regdesc, self.device_id)
 
-    async def basic_ventilation_enable(self) -> Result[int]:
-        """Get base ventilation enabled."""
-        return await self.client.get_register(
-            self.regmap[vp.BASIC_VENTILATION_ENABLE], self.device_id
-        )
+    async def preheater_setpoint(self) -> Result[float]:
+        """Get the preheater setpoint."""
+        return await self.client.get_register(self.regmap[vp.PREHEATER_SETPOINT], self.device_id)
 
-    async def set_basic_ventilation_enable(self, mode: int) -> bool:
-        """Set base ventilation enabled=1/disabled=0."""
+    async def set_preheater_setpoint(self, value: float) -> bool:
+        """Set the preheater setpoint."""
         return await self.client.set_register(
-            self.regmap[vp.BASIC_VENTILATION_ENABLE], mode, self.device_id
+            self.regmap[vp.PREHEATER_SETPOINT], value, self.device_id
         )
 
-    async def basic_ventilation_level(self) -> Result[int]:
-        """Get base ventilation level."""
+    async def free_ventilation_setpoint(self) -> Result[float]:
+        """Get the free ventilation setpoint."""
         return await self.client.get_register(
-            self.regmap[vp.BASIC_VENTILATION_LEVEL], self.device_id
+            self.regmap[vp.FREE_VENTILATION_HEATING_SETPOINT], self.device_id
         )
 
-    async def set_basic_ventilation_level(self, level: int) -> bool:
-        """Set the base ventilation level."""
+    async def set_free_ventilation_setpoint(self, value: float) -> bool:
+        """Set the free ventilation setpoint."""
         return await self.client.set_register(
-            self.regmap[vp.BASIC_VENTILATION_LEVEL], level, self.device_id
+            self.regmap[vp.FREE_VENTILATION_HEATING_SETPOINT], value, self.device_id
         )
 
-    async def product_variant(self) -> Result[int]:
-        """Get the product variant."""
-        regdesc = self.regmap[vp.PRODUCT_VARIANT]
-        return await self.client.get_register(regdesc, self.device_id)
+    async def free_ventilation_cooling_offset(self) -> Result[float]:
+        """Get the free ventilation cooling offset."""
+        return await self.client.get_register(
+            self.regmap[vp.FREE_VENTILATION_COOLING_OFFSET], self.device_id
+        )
+
+    async def set_free_ventilation_cooling_offset(self, value: float) -> bool:
+        """Set the free ventilation cooling offset."""
+        return await self.client.set_register(
+            self.regmap[vp.FREE_VENTILATION_COOLING_OFFSET], value, self.device_id
+        )
+
+    async def frost_protection_preheater_setpoint(self) -> Result[float]:
+        """Get the frost protection preheater setpoint."""
+        return await self.client.get_register(
+            self.regmap[vp.FROST_PROTECTION_PREHEATER_SETPOINT], self.device_id
+        )
+
+    async def set_frost_protection_preheater_setpoint(self, value: float) -> bool:
+        """Set the frost protection preheater setpoint."""
+        return await self.client.set_register(
+            self.regmap[vp.FROST_PROTECTION_PREHEATER_SETPOINT], value, self.device_id
+        )
+
+    async def preset_high_fan_speed_supply(self) -> Result[int]:
+        """Get the supply fan speed for the high preset."""
+        return await self.client.get_register(self.regmap[vp.FAN_SPEED_HIGH_SUPPLY], self.device_id)
+
+    async def set_preset_high_fan_speed_supply(self, value: int) -> bool:
+        """Set the supply fan speed for the high preset."""
+        return await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_HIGH_SUPPLY], value, self.device_id
+        )
+
+    async def preset_high_fan_speed_exhaust(self) -> Result[int]:
+        """Get the exhaust fan speed for the high preset."""
+        return await self.client.get_register(
+            self.regmap[vp.FAN_SPEED_HIGH_EXHAUST], self.device_id
+        )
+
+    async def set_preset_high_fan_speed_exhaust(self, value: int) -> bool:
+        """Set the exhaust fan speed for the high preset."""
+        return await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_HIGH_EXHAUST], value, self.device_id
+        )
+
+    async def preset_medium_fan_speed_supply(self) -> Result[int]:
+        """Get the supply fan speed for the medium preset."""
+        return await self.client.get_register(self.regmap[vp.FAN_SPEED_MID_SUPPLY], self.device_id)
+
+    async def set_preset_medium_fan_speed_supply(self, value: int) -> bool:
+        """Set the supply fan speed for the medium preset."""
+        return await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_MID_SUPPLY], value, self.device_id
+        )
+
+    async def preset_medium_fan_speed_exhaust(self) -> Result[int]:
+        """Get the exhaust fan speed for the medium preset."""
+        return await self.client.get_register(self.regmap[vp.FAN_SPEED_MID_EXHAUST], self.device_id)
+
+    async def set_preset_medium_fan_speed_exhaust(self, value: int) -> bool:
+        """Set the exhaust fan speed for the medium preset."""
+        return await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_MID_EXHAUST], value, self.device_id
+        )
+
+    async def preset_low_fan_speed_supply(self) -> Result[int]:
+        """Get the supply fan speed for the low preset."""
+        return await self.client.get_register(self.regmap[vp.FAN_SPEED_LOW_SUPPLY], self.device_id)
+
+    async def set_preset_low_fan_speed_supply(self, value: int) -> bool:
+        """Set the supply fan speed for the low preset."""
+        return await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_LOW_SUPPLY], value, self.device_id
+        )
+
+    async def preset_low_fan_speed_exhaust(self) -> Result[int]:
+        """Get the exhaust fan speed for the low preset."""
+        return await self.client.get_register(self.regmap[vp.FAN_SPEED_LOW_EXHAUST], self.device_id)
+
+    async def set_preset_low_fan_speed_exhaust(self, value: int) -> bool:
+        """Set the exhaust fan speed for the low preset."""
+        return await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_LOW_EXHAUST], value, self.device_id
+        )
+
+    async def preset_standby_fan_speed_supply(self) -> Result[int]:
+        """Get the supply fan speed for the standby preset."""
+        return await self.client.get_register(self.regmap[vp.FAN_SPEED_AWAY_SUPPLY], self.device_id)
+
+    async def set_preset_standby_fan_speed_supply(self, value: int) -> bool:
+        """Set the supply fan speed for the standby preset."""
+        return await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_AWAY_SUPPLY], value, self.device_id
+        )
+
+    async def preset_standby_fan_speed_exhaust(self) -> Result[int]:
+        """Get the exhaust fan speed for the standby preset."""
+        return await self.client.get_register(
+            self.regmap[vp.FAN_SPEED_AWAY_EXHAUST], self.device_id
+        )
+
+    async def set_preset_standby_fan_speed_exhaust(self, value: int) -> bool:
+        """Set the exhaust fan speed for the standby preset."""
+        return await self.client.set_register(
+            self.regmap[vp.FAN_SPEED_AWAY_EXHAUST], value, self.device_id
+        )
 
     async def inlet_flow(self) -> Result[VMDFlowLevel]:
         """Get the inlet flow level (in m3/h)"""
@@ -541,10 +735,10 @@ class VMD15RMS86(AiriosNode):
         regdesc = self.regmap[vp.FLOW_OUTLET]
         return await self.client.get_register(regdesc, self.device_id)
 
-    async def co2_level(self) -> Result[VMDCO2Level]:
-        """Get the CO2 level (in ppm)."""
-        regdesc = self.regmap[vp.CO2_LEVEL]
-        return await self.client.get_register(regdesc, self.device_id)
+    # async def co2_level(self) -> Result[VMDCO2Level]:
+    #     """Get the CO2 level (in ppm)."""
+    #     regdesc = self.regmap[vp.CO2_LEVEL]
+    #     return await self.client.get_register(regdesc, self.device_id)
 
     async def co2_setpoint(self) -> Result[int]:
         """Get the CO2 control setpoint (in ppm)."""
@@ -554,4 +748,14 @@ class VMD15RMS86(AiriosNode):
     async def set_co2_setpoint(self, setpnt: int) -> bool:
         """Set the CO2 control setpoint (in ppm)."""
         regdesc = self.regmap[vp.CO2_CONTROL_SETPOINT]
+        return await self.client.set_register(regdesc, setpnt, self.device_id)
+
+    async def temperature_setpoint(self) -> Result[int]:
+        """Get the Temperature control setpoint (in ˚C)."""
+        regdesc = self.regmap[vp.TEMPERATURE_CONTROL_SETPOINT]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def set_temperature_setpoint(self, setpnt: int) -> bool:
+        """Set the Temperature control setpoint (in ˚C)."""
+        regdesc = self.regmap[vp.TEMPERATURE_CONTROL_SETPOINT]
         return await self.client.set_register(regdesc, setpnt, self.device_id)

--- a/src/pyairios/models/vmd_15rms86.py
+++ b/src/pyairios/models/vmd_15rms86.py
@@ -248,7 +248,7 @@ class VMD15RMS86(AiriosNode):
             U16Register(vp.BYPASS_STATUS, 41051, RegisterAccess.READ | RegisterAccess.STATUS),
             U16Register(
                 vp.REQUESTED_VENTILATION_SPEED,
-                41500,  # to be confirmed by remy
+                41500,
                 RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
             ),
             # U16Register(
@@ -325,8 +325,8 @@ class VMD15RMS86(AiriosNode):
             ),
             U16Register(vp.CO2_CONTROL_SETPOINT, 49017, RegisterAccess.READ | RegisterAccess.WRITE),
             U16Register(
-                vp.TEMPERATURE_CONTROL_SETPOINT, 49017, RegisterAccess.READ | RegisterAccess.WRITE
-            ),  # TODO fill in correct register
+                vp.TEMPERATURE_CONTROL_SETPOINT, 49019, RegisterAccess.READ | RegisterAccess.WRITE
+            ),
             # FloatRegister(
             #     vp.FROST_PROTECTION_PREHEATER_SETPOINT,
             #     42009,

--- a/src/pyairios/models/vmd_15rms86.py
+++ b/src/pyairios/models/vmd_15rms86.py
@@ -1,4 +1,4 @@
-"""Airios VMD-15RPS86 controller implementation (generic Orcon)."""
+"""Airios VMD-15RMS86 controller implementation (generic Orcon)."""
 
 from __future__ import annotations
 
@@ -41,10 +41,10 @@ LOGGER = logging.getLogger(__name__)
 
 def pr_id() -> ProductId:
     """
-    Get product_id for model VMD_15RPS86.
+    Get product_id for model VMD_15RMS86.
     Named as is to discern from product_id register.
     """
-    return ProductId.VMD_15RPS86
+    return ProductId.VMD_15RMS86
 
 
 def pr_type() -> AiriosDeviceType:
@@ -56,7 +56,7 @@ def pr_type() -> AiriosDeviceType:
 
 def pr_description() -> list[str]:
     """
-    Get description of product(s) using VMD_15RPS86.
+    Get description of product(s) using VMD_15RMS86.
     Human-readable text, used in e.g. HomeAssistant Binding UI.
     :return: string or tuple of strings, starting with manufacturer
     """

--- a/src/pyairios/models/vmd_15rms86.py
+++ b/src/pyairios/models/vmd_15rms86.py
@@ -1,0 +1,557 @@
+"""Airios VMD-99RPS99 controller implementation (Orcon)."""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import List
+
+from pyairios.client import AsyncAiriosModbusClient
+from pyairios.constants import (
+    AiriosDeviceType,
+    ProductId,
+    VMDBypassPosition,
+    VMDCO2Level,
+    VMDErrorCode,
+    VMDFlowLevel,
+    VMDHeater,
+    VMDHeaterStatus,
+    VMDHumidity,
+    VMDRequestedVentilationSpeed,
+    VMDSensorStatus,
+    VMDTemperature,
+    VMDVentilationMode,
+    VMDVentilationSpeed,
+)
+from pyairios.node import AiriosNode
+from pyairios.properties import AiriosVMDProperty as vp
+from pyairios.registers import (
+    FloatRegister,
+    RegisterAccess,
+    RegisterBase,
+    Result,
+    U8Register,
+    U16Register,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def pr_id() -> ProductId:
+    """
+    Get product_id for model VMD_07RPS13.
+    Named as is to discern from product_id register.
+    """
+    return ProductId.VMD_07RPS13
+
+
+def pr_type() -> AiriosDeviceType:
+    """
+    Get the device type.
+    """
+    return AiriosDeviceType.CONTROLLER
+
+
+def pr_description() -> list[str]:
+    """
+    Get description of product(s) using VMD_07RPS13.
+    Human-readable text, used in e.g. HomeAssistant Binding UI.
+    :return: string or tuple of strings, starting with manufacturer
+    """
+    return ["ClimaRad Ventura V1"]
+
+
+def pr_instantiate(device_id: int, client: AsyncAiriosModbusClient) -> VMD07RPS13:
+    """Get a new device instance. Used by the device factory to instantiate by product ID."""
+    return VMD07RPS13(device_id, client)
+
+
+def _temperature_adapter(value: float) -> VMDTemperature:
+    if math.isnan(value):
+        status = VMDSensorStatus.UNAVAILABLE
+    elif value < -273.0:
+        status = VMDSensorStatus.ERROR
+    else:
+        status = VMDSensorStatus.OK
+        value = round(value, 2)
+    return VMDTemperature(value, status)
+
+
+def _humidity_adapter(value: int) -> VMDHumidity:
+    status = VMDSensorStatus.OK
+    if value == 0xEF:
+        status = VMDSensorStatus.UNAVAILABLE
+    elif value == 0xF0:
+        status = VMDSensorStatus.SHORT_CIRCUIT
+    elif value == 0xF1:
+        status = VMDSensorStatus.OPEN_CIRCUIT
+    elif value == 0xF2:
+        status = VMDSensorStatus.ERROR_UNAVAILABLE
+    elif value == 0xF3:
+        status = VMDSensorStatus.OVERFLOW
+    elif value == 0xF4:
+        status = VMDSensorStatus.UNDERFLOW
+    elif value == 0xF5:
+        status = VMDSensorStatus.UNRELIABLE
+    elif 0xF6 <= value <= 0xFE:
+        status = VMDSensorStatus.ERROR_RESERVED
+    elif value == 0xFF:
+        status = VMDSensorStatus.ERROR
+    return VMDHumidity(value, status)
+
+
+def _co2_adapter(value: int) -> VMDCO2Level:
+    status = VMDSensorStatus.OK
+    if value == 0x7FFF:
+        status = VMDSensorStatus.UNAVAILABLE
+    elif 0x8000 <= value <= 0xFFFF:
+        status = VMDSensorStatus.ERROR
+    return VMDCO2Level(value, status)
+
+
+def _flow_adapter(value: int) -> VMDFlowLevel:
+    status = VMDSensorStatus.OK
+    if value == 0x7FFF:
+        status = VMDSensorStatus.UNAVAILABLE
+    elif 0x8000 <= value <= 0x85FF:
+        status = VMDSensorStatus.ERROR
+    return VMDFlowLevel(value, status)
+
+
+def _bypass_position_adapter(value) -> VMDBypassPosition:
+    error = value > 120
+    return VMDBypassPosition(value, error)
+
+
+def _heater_adapter(value) -> VMDHeater:
+    status = VMDHeaterStatus.UNAVAILABLE if value == 0xEF else VMDHeaterStatus.OK
+    return VMDHeater(value, status)
+
+
+class VMD15RMS86(AiriosNode):
+    """Represents a VMD-15RMS86 controller node."""
+
+    def __init__(self, device_id: int, client: AsyncAiriosModbusClient) -> None:
+        """Initialize the VMD-15RMS86 Orcon controller node instance."""
+        super().__init__(device_id, client)
+        vmd_registers: List[RegisterBase] = [
+            FloatRegister(
+                vp.TEMPERATURE_OUTLET,
+                41000,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_temperature_adapter,
+            ),
+            U8Register(
+                vp.HUMIDITY_OUTDOOR,
+                41002,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_humidity_adapter,
+            ),
+            FloatRegister(
+                vp.TEMPERATURE_INLET,
+                41003,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_temperature_adapter,
+            ),
+            FloatRegister(
+                vp.TEMPERATURE_EXHAUST,
+                41005,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_temperature_adapter,
+            ),
+            U8Register(
+                vp.HUMIDITY_INDOOR,
+                41007,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_humidity_adapter,
+            ),
+            U16Register(
+                vp.CO2_LEVEL,
+                41008,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_co2_adapter,
+            ),
+            U8Register(
+                vp.BYPASS_POSITION,
+                41015,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_bypass_position_adapter,
+            ),
+            U8Register(vp.FILTER_DIRTY, 41017, RegisterAccess.READ | RegisterAccess.STATUS),
+            U8Register(vp.FAN_SPEED_EXHAUST, 41019, RegisterAccess.READ | RegisterAccess.STATUS),
+            U8Register(vp.FAN_SPEED_SUPPLY, 41020, RegisterAccess.READ | RegisterAccess.STATUS),
+            U8Register(
+                vp.POSTHEATER,
+                41023,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_heater_adapter,
+            ),
+            FloatRegister(
+                vp.FLOW_INLET,
+                41024,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_flow_adapter,
+            ),
+            FloatRegister(
+                vp.FLOW_OUTLET,
+                41026,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_adapter=_flow_adapter,
+            ),
+            U16Register(
+                vp.FILTER_REMAINING_DAYS, 41028, RegisterAccess.READ | RegisterAccess.STATUS
+            ),
+            U16Register(vp.FILTER_DURATION, 41029, RegisterAccess.READ | RegisterAccess.STATUS),
+            U8Register(
+                vp.FILTER_REMAINING_PERCENT, 41030, RegisterAccess.READ | RegisterAccess.STATUS
+            ),
+            U8Register(vp.ERROR_CODE, 41032, RegisterAccess.READ | RegisterAccess.STATUS),
+            U8Register(
+                vp.VENTILATION_MODE,
+                41100,
+                RegisterAccess.READ | RegisterAccess.STATUS,
+                result_type=VMDVentilationMode,
+            ),
+            U8Register(vp.VENTILATION_SUB_MODE, 41101, RegisterAccess.READ | RegisterAccess.STATUS),
+            U8Register(
+                vp.TEMP_VENTILATION_MODE, 41103, RegisterAccess.READ | RegisterAccess.STATUS
+            ),
+            U8Register(
+                vp.TEMP_VENTILATION_SUB_MODE, 41104, RegisterAccess.READ | RegisterAccess.STATUS
+            ),
+            U8Register(
+                vp.REQUESTED_VENTILATION_MODE,
+                41120,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            ),
+            U8Register(
+                vp.REQUESTED_VENTILATION_SUB_MODE,
+                41121,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            ),
+            U8Register(
+                vp.REQUESTED_TEMP_VENTILATION_MODE,
+                41123,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            ),
+            U8Register(
+                vp.REQUESTED_TEMP_VENTILATION_SUB_MODE,
+                41124,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            ),
+            U8Register(vp.FILTER_RESET, 41151, RegisterAccess.WRITE | RegisterAccess.STATUS),
+            U8Register(
+                vp.BASIC_VENTILATION_ENABLE,
+                42000,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            ),
+            U8Register(
+                vp.BASIC_VENTILATION_LEVEL,
+                42001,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            ),
+            U16Register(
+                vp.TEMP_OVERRIDE_DURATION, 42009, (RegisterAccess.READ | RegisterAccess.WRITE)
+            ),
+            U16Register(vp.CO2_CONTROL_SETPOINT, 42011, RegisterAccess.READ | RegisterAccess.WRITE),
+            U8Register(
+                vp.PRODUCT_VARIANT,
+                41010,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            ),
+            U8Register(
+                vp.SYSTEM_VENTILATION_CONFIGURATION,
+                42021,
+                RegisterAccess.READ | RegisterAccess.WRITE | RegisterAccess.STATUS,
+            ),
+        ]
+        self._add_registers(vmd_registers)
+
+    def __str__(self) -> str:
+        return f"VMD-07RPS13@{self.device_id}"
+
+    def pr_id(self) -> ProductId:
+        return pr_id()
+
+    def pr_type(self) -> AiriosDeviceType:
+        return pr_type()
+
+    def pr_description(self) -> list[str]:
+        return pr_description()
+
+    async def ventilation_speed(self) -> Result[VMDVentilationSpeed]:
+        """Get the ventilation unit active speed preset."""
+
+        # Automatic:
+        # Ventilation mode:        2
+        # Ventilation sub mode:    48
+        # Temp. Ventil. mode:      0
+        # Temp. Ventil. sub mode:  0
+        #
+        # Pause:
+        # Ventilation mode:        1
+        # Ventilation sub mode:    0
+        # Temp. Ventil. mode:      1
+        # Temp. Ventil. sub mode:  0
+        #
+        # Manual/temp 1:
+        # Ventilation mode:        0
+        # Ventilation sub mode:    0
+        # Temp. Ventil. mode:      3
+        # Temp. Ventil. sub mode:  201
+        #
+        # Manual/temp 2:
+        # Ventilation mode:        0
+        # Ventilation sub mode:    0
+        # Temp. Ventil. mode:      3
+        # Temp. Ventil. sub mode:  202
+        #
+        # Ventilation mode:        0
+        # Ventilation sub mode:    0
+        # Temp. Ventil. mode:      3
+        # Temp. Ventil. sub mode:  203
+        #
+        # Stand 5 == Boost >>
+        # Ventilation mode:        0
+        # Ventilation sub mode:    0
+        # Temp. Ventil. mode:      3
+        # Temp. Ventil. sub mode:  205
+
+        mode = await self.client.get_register(self.regmap[vp.VENTILATION_MODE], self.device_id)
+        man_step = await self.client.get_register(
+            self.regmap[vp.TEMP_VENTILATION_SUB_MODE], self.device_id
+        )
+        speed = VMDVentilationSpeed.OFF
+        if mode.value == 2:
+            speed = VMDVentilationSpeed.AUTO
+        elif mode.value == 1:
+            speed = VMDVentilationSpeed.AWAY
+        elif mode.value == 0:
+            if man_step.value <= 202:
+                speed = VMDVentilationSpeed.OVERRIDE_LOW
+            elif man_step.value <= 203:
+                speed = VMDVentilationSpeed.OVERRIDE_MID
+            elif man_step.value <= 205:
+                speed = VMDVentilationSpeed.OVERRIDE_HIGH
+        return Result(speed, mode.status)
+
+    async def set_ventilation_speed(self, speed: VMDRequestedVentilationSpeed) -> bool:
+        """Set the ventilation unit speed (temp 8H) preset."""
+        md = 0  # VMDVentilationSpeed.OFF, PAUSE?
+        if speed == VMDRequestedVentilationSpeed.AUTO:
+            md = 0
+        elif speed == VMDRequestedVentilationSpeed.AWAY:
+            md = 0
+        elif speed == VMDRequestedVentilationSpeed.LOW:
+            md = 202
+        elif speed == VMDRequestedVentilationSpeed.MID:
+            md = 203
+        elif speed == VMDRequestedVentilationSpeed.HIGH:
+            md = 205
+
+        regdesc = self.regmap[vp.REQUESTED_VENTILATION_SUB_MODE]
+        # check why no immediate change
+        return await self.client.set_register(regdesc, md, self.device_id)
+
+    async def system_ventilation_configuration(self) -> Result[int]:
+        """Get the system ventilation configuration status."""
+        regdesc = self.regmap[vp.SYSTEM_VENTILATION_CONFIGURATION]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def ventilation_mode(self) -> Result[VMDVentilationMode]:
+        """Get the ventilation mode status. 0=Off, 1=Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        # seen: 0 (with temp_vent_mode 3) | 1 = Pause | 2 = On (with vent_sub_mode 48)
+        regdesc = self.regmap[vp.VENTILATION_MODE]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def set_ventilation_mode(self, mode: VMDVentilationMode) -> bool:
+        """Set the ventilation mode. 0=Off, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        regdesc = self.regmap[vp.REQUESTED_VENTILATION_MODE]
+        return await self.client.set_register(regdesc, mode, self.device_id)
+
+    async def requested_ventilation_mode(self) -> Result[VMDVentilationMode]:
+        """Get the ventilation mode status. 0=Off, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        regdesc = self.regmap[vp.REQUESTED_VENTILATION_MODE]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def ventilation_sub_mode(self) -> Result[int]:
+        """Get the ventilation sub mode status."""
+        # seen: 0 | 48
+        regdesc = self.regmap[vp.VENTILATION_SUB_MODE]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def set_ventilation_sub_mode(self, mode: int) -> bool:
+        """Set the ventilation sub mode. 0=Off/Pause, 48=Auto"""
+        regdesc = self.regmap[vp.REQUESTED_VENTILATION_SUB_MODE]
+        return await self.client.set_register(regdesc, mode, self.device_id)
+
+    async def requested_ventilation_sub_mode(self) -> Result[int]:
+        """Get the ventilation mode status. 0=Off/Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        regdesc = self.regmap[vp.REQUESTED_VENTILATION_SUB_MODE]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def temp_ventilation_mode(self) -> Result[int]:
+        """Get the temporary ventilation mode status."""
+        # seen: 0 (with Ventilation mode != 0) | 3
+        regdesc = self.regmap[vp.TEMP_VENTILATION_MODE]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def temp_ventilation_sub_mode(self) -> Result[int]:
+        """Get the temporary ventilation sub mode status."""
+        # seen: 0 (with temp_vent_mode 3) | 201 | 202 | .. | 205
+        regdesc = self.regmap[vp.TEMP_VENTILATION_SUB_MODE]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def set_temp_ventilation_mode(self, mode: int) -> bool:
+        """Set the temp ventilation mode. 0=Off, 1=Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        regdesc = self.regmap[vp.REQUESTED_TEMP_VENTILATION_MODE]
+        return await self.client.set_register(regdesc, mode, self.device_id)
+
+    async def requested_temp_ventilation_mode(self) -> Result[int]:
+        """Get the temp ventilation mode status. 0=Off, 1=Pause, 2=On, 3=Man1, 5=Man3, 8=Service"""
+        regdesc = self.regmap[vp.REQUESTED_TEMP_VENTILATION_MODE]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def set_temp_ventilation_sub_mode(self, mode: int) -> bool:
+        """Set the temp ventilation sub mode. 0=Off/Pause, 201, ..."""
+        regdesc = self.regmap[vp.REQUESTED_TEMP_VENTILATION_SUB_MODE]
+        return await self.client.set_register(regdesc, mode, self.device_id)
+
+    async def requested_temp_ventilation_sub_mode(self) -> Result[int]:
+        """Get the temp ventilation sub mode status. 0=Off/Pause, 201, ..."""
+        regdesc = self.regmap[vp.REQUESTED_TEMP_VENTILATION_SUB_MODE]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def bypass_position(self) -> Result[VMDBypassPosition]:
+        """Get the bypass position."""
+        regdesc = self.regmap[vp.BYPASS_POSITION]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def filter_duration(self) -> Result[int]:
+        """Get the filter duration (in days)."""
+        return await self.client.get_register(self.regmap[vp.FILTER_DURATION], self.device_id)
+
+    async def filter_remaining_days(self) -> Result[int]:
+        """Get the filter remaining lifetime (in days)."""
+        return await self.client.get_register(self.regmap[vp.FILTER_REMAINING_DAYS], self.device_id)
+
+    async def filter_remaining_percent(self) -> Result[int]:
+        """Get the filter remaining lifetime (in %)."""
+        return await self.client.get_register(
+            self.regmap[vp.FILTER_REMAINING_PERCENT], self.device_id
+        )
+
+    async def filter_reset(self) -> bool:
+        """Reset the filter dirty status."""
+        return await self.client.set_register(self.regmap[vp.FILTER_RESET], 0, self.device_id)
+
+    async def filter_dirty(self) -> Result[int]:
+        """Get the filter dirty status."""
+        regdesc = self.regmap[vp.FILTER_DIRTY]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def error_code(self) -> Result[VMDErrorCode]:
+        """Get the ventilation unit error code."""
+        regdesc = self.regmap[vp.ERROR_CODE]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def indoor_humidity(self) -> Result[VMDHumidity]:
+        """Get the indoor humidity (%)"""
+        regdesc = self.regmap[vp.HUMIDITY_INDOOR]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def outdoor_humidity(self) -> Result[VMDHumidity]:
+        """Get the outdoor humidity (%)"""
+        regdesc = self.regmap[vp.HUMIDITY_OUTDOOR]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def exhaust_fan_speed(self) -> Result[int]:
+        """Get the exhaust fan speed (%)"""
+        return await self.client.get_register(self.regmap[vp.FAN_SPEED_EXHAUST], self.device_id)
+
+    async def supply_fan_speed(self) -> Result[int]:
+        """Get the supply fan speed (%)"""
+        return await self.client.get_register(self.regmap[vp.FAN_SPEED_SUPPLY], self.device_id)
+
+    async def indoor_air_temperature(self) -> Result[VMDTemperature]:
+        """Get the indoor air temperature.
+
+        This is exhaust flow before the heat exchanger.
+        """
+        regdesc = self.regmap[vp.TEMPERATURE_EXHAUST]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def outdoor_air_temperature(self) -> Result[VMDTemperature]:
+        """Get the outdoor air temperature.
+
+        This is the supply flow before the heat exchanger.
+        """
+        regdesc = self.regmap[vp.TEMPERATURE_INLET]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def exhaust_air_temperature(self) -> Result[VMDTemperature]:
+        """Get the exhaust air temperature.
+
+        This is the exhaust flow after the heat exchanger.
+        """
+        regdesc = self.regmap[vp.TEMPERATURE_OUTLET]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def postheater(self) -> Result[VMDHeater]:
+        """Get the postheater level."""
+        regdesc = self.regmap[vp.POSTHEATER]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def basic_ventilation_enable(self) -> Result[int]:
+        """Get base ventilation enabled."""
+        return await self.client.get_register(
+            self.regmap[vp.BASIC_VENTILATION_ENABLE], self.device_id
+        )
+
+    async def set_basic_ventilation_enable(self, mode: int) -> bool:
+        """Set base ventilation enabled=1/disabled=0."""
+        return await self.client.set_register(
+            self.regmap[vp.BASIC_VENTILATION_ENABLE], mode, self.device_id
+        )
+
+    async def basic_ventilation_level(self) -> Result[int]:
+        """Get base ventilation level."""
+        return await self.client.get_register(
+            self.regmap[vp.BASIC_VENTILATION_LEVEL], self.device_id
+        )
+
+    async def set_basic_ventilation_level(self, level: int) -> bool:
+        """Set the base ventilation level."""
+        return await self.client.set_register(
+            self.regmap[vp.BASIC_VENTILATION_LEVEL], level, self.device_id
+        )
+
+    async def product_variant(self) -> Result[int]:
+        """Get the product variant."""
+        regdesc = self.regmap[vp.PRODUCT_VARIANT]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def inlet_flow(self) -> Result[VMDFlowLevel]:
+        """Get the inlet flow level (in m3/h)"""
+        regdesc = self.regmap[vp.FLOW_INLET]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def outlet_flow(self) -> Result[VMDFlowLevel]:
+        """Get the outlet flow level (in m3/h)"""
+        regdesc = self.regmap[vp.FLOW_OUTLET]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def co2_level(self) -> Result[VMDCO2Level]:
+        """Get the CO2 level (in ppm)."""
+        regdesc = self.regmap[vp.CO2_LEVEL]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def co2_setpoint(self) -> Result[int]:
+        """Get the CO2 control setpoint (in ppm)."""
+        regdesc = self.regmap[vp.CO2_CONTROL_SETPOINT]
+        return await self.client.get_register(regdesc, self.device_id)
+
+    async def set_co2_setpoint(self, setpnt: int) -> bool:
+        """Set the CO2 control setpoint (in ppm)."""
+        regdesc = self.regmap[vp.CO2_CONTROL_SETPOINT]
+        return await self.client.set_register(regdesc, setpnt, self.device_id)

--- a/src/pyairios/models/vmd_15rms86.py
+++ b/src/pyairios/models/vmd_15rms86.py
@@ -326,7 +326,7 @@ class VMD15RMS86(AiriosNode):
             U16Register(vp.CO2_CONTROL_SETPOINT, 49017, RegisterAccess.READ | RegisterAccess.WRITE),
             U16Register(
                 vp.TEMPERATURE_CONTROL_SETPOINT, 49017, RegisterAccess.READ | RegisterAccess.WRITE
-            ),
+            ),  # TODO fill in correct register
             # FloatRegister(
             #     vp.FROST_PROTECTION_PREHEATER_SETPOINT,
             #     42009,

--- a/src/pyairios/properties.py
+++ b/src/pyairios/properties.py
@@ -137,12 +137,16 @@ class AiriosVMDProperty(AiriosBaseProperty):
     TEMPERATURE_SUPPLY = auto()
     """Incoming air temperature after heat exchanger."""
 
+    TEMPERATURE_CONTROL_SETPOINT = auto()
+    """Supply Air to room temperature setpoint."""
+
     PREHEATER = auto()
     FILTER_DIRTY = auto()
     DEFROST = auto()
     BYPASS_POSITION = auto()
     HUMIDITY_INDOOR = auto()
     HUMIDITY_OUTDOOR = auto()
+    HUMIDITY_CONTROL_SETPOINT = auto()
     FLOW_INLET = auto()
     FLOW_OUTLET = auto()
     AIR_QUALITY = auto()


### PR DESCRIPTION
Adds support for the **BRDG-02EM23** Ethernet bridge (sold by Siber as
`DFEVORFETH`), tested end to end against real hardware.

This builds directly on @silverailscolo's `eb-orcon-model` branch — the model
class, the transport-based bridge selection and the `ProductId` entry are their
work. They don't own the hardware, so I completed the three TODOs their branch
left open, with values read from a live bridge. Discussion in #13.

## What was missing, and what the hardware says

**1. The product ID.** The branch had
`BRDG_02EM23 = 0x0001C800  # TODO fill in a verified ID`. My bridge reports
`116808` = **`0x0001C848`** on register `40002` — one below
`BRDG_02R13 = 0x0001C849`. Cross-checked against `PRODUCT_NAME` (`40011`), which
reads `'BRDG-02EM23'`.

**2. The default Modbus device id.** The new model carried the RS485 default of
`207`. The Ethernet bridge answers on id **1**, with the first bound unit on 2.

**3. The serial registers.** The Ethernet model inherited `41998` parity,
`41999` stop bits, `42000` baudrate and `42001` Modbus device id from the RS485
model. The bridge answers `IllegalDataAddress` (exception code 2) for all four,
and because `fetch()` walks every readable register, **their presence made every
fetch fail**:

```
pyairios.exceptions.AiriosReadException: Got an error while reading register 41998
(length 4) from device id 1: ExceptionResponse(dev_id=1, function_code=131, exception_code=2)
```

This PR removes those registers plus the `serial_config()` /
`set_serial_config()` methods that read them, and the imports left unused.

## Test results

Hardware: `BRDG-02EM23` Ethernet bridge + bound `VMD-02RPS78-2`
(Siber DF EVO 2 ducted unit). pyairios on Python 3.13, Modbus TCP on port 502.

```
connect(): True

bridge identity
  product id                   <ProductId.BRDG_02EM23: 116808>
  product name                 'BRDG-02EM23'
  software version             65329
  rf address                   7893700
  bridge class                 BRDG02EM23

nodes()
  modbus id 2: 0x0001C892 (VMD-02RPS78) rf=0x821EC4 ['Siber DF Evo', 'Siber DF Optima 2']

fetch(all_props=False, with_status=False)   → node 1: 60 props, node 2: 52 props
fetch(all_props=True,  with_status=True)    → node 1: 76 props, node 2: 79 props
```

## README

Also updated the *Supported devices* list: the tested unit is a **Siber DF Evo 2**
(the bridge reports the bound node's description as
`['Siber DF Evo', 'Siber DF Optima 2']`, same `VMD-02RPS78` controller), and added
the Ethernet bridge itself — sold by Siber as **DFEVORFETH** — since that is the
piece this PR is about.

One thing I noticed while doing that, and I may well be misreading it: the Orcon
line lists `Airios VMD-02EM23-2`, but `EM23` looks like the bridge family rather
than a unit controller, and the branch's new unit model is `vmd_15rms86.py` /
`ProductId.VMD_15RPS86`. Should that line say `VMD-15RPS86`? I've left it
untouched in case it is intentional. (Tiny related nit: the module is named
`vmd_15rms86.py` — RMS — while the enum says `VMD_15RPS86` — RPS.)

No behaviour change for RS485 users: `BRDG02R13` keeps its own registers and its
`DEFAULT_DEVICE_ID = 207`.

## Notes from the hardware that may be worth follow-up work

Not addressed in this PR, to keep it focused, but happy to send separate patches:

- **Cached registers.** `41003` (error code) and `41040`-`41042` (filter days /
  duration / percentage) fail on the first read after boot and answer on the
  second. A single retry would make them reliable.
- **Write-only register.** `41500` (requested ventilation speed) is not readable
  on `VMD-02RPS78-2`; reads raise. The actual speed is `41000`.
- **"Sensor not fitted" markers.** `239` (0xEF) and `32767` (0x7FFF) are not
  measurements. On my unit that covers indoor/outdoor humidity, air quality, CO2
  and both heaters, so consumers should skip those entities rather than report
  239 %.
- **Capability bits.** `41027` tells you which modes the unit supports — mine
  reports `61440` (boost + timer + off, no auto), so a fixed mode list would
  offer something the unit cannot do.

## Getting the bridge to speak local Modbus TCP at all

Worth documenting somewhere, because it stops most people before they get here:
out of the box this bridge is a Modbus-over-WebSocket *client* towards the vendor
cloud and has **zero open TCP ports**. It only listens on 502 if you pair it
*without* configuring the cloud server URL (factory reset, set outgoing product
type, bind the unit as slave 2, and stop before the "Server URL" step). Also, it
accepts exactly **one** Modbus connection at a time.

I have the hardware here and I'm happy to test any further change.
